### PR TITLE
Set up docs page using mkdocs and github pages.

### DIFF
--- a/.github/workflows/mkdocs-deploy.yml
+++ b/.github/workflows/mkdocs-deploy.yml
@@ -1,0 +1,30 @@
+name: "MkDocs Deploy"
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - "docs/**"
+permissions:
+  contents: write
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: 3.x
+      - name: Generate Cache ID
+        run: echo "cache_id=$(date --utc '+%V')" >> $GITHUB_ENV 
+      - name: Set up Cache
+        uses: actions/cache@v3
+        with:
+          key: mkdocs-material-${{ env.cache_id }}
+          path: .cache
+          restore-keys: |
+            mkdocs-material-
+      - run: pip install mkdocs-material 
+      - run: mkdocs gh-deploy --force

--- a/docs/Dockerfile
+++ b/docs/Dockerfile
@@ -1,0 +1,8 @@
+FROM python:alpine
+
+RUN pip install mkdocs
+RUN pip install mkdocs-material
+
+WORKDIR /docs
+
+CMD ["mkdocs", "serve"]

--- a/docs/docker-compose.yaml
+++ b/docs/docker-compose.yaml
@@ -1,0 +1,11 @@
+version: "3.9"
+services:
+  frontend:
+    build: .
+    ports:
+      - target: 4627
+        published: 4627
+    volumes:
+      - type: bind
+        source: .
+        target: /docs

--- a/docs/docs/README.md
+++ b/docs/docs/README.md
@@ -1,3 +1,3 @@
 # Spelman Dashboard Developer Docs
 
-Check out our documentation for developers [here](https://github.com/Spelman-College).
+Check out our documentation for developers [here](https://spelman-college.github.io/spelman-dashboard).

--- a/docs/docs/README.md
+++ b/docs/docs/README.md
@@ -1,0 +1,3 @@
+# Spelman Dashboard Developer Docs
+
+Check out our documentation for developers [here](https://github.com/Spelman-College).

--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -1,0 +1,5 @@
+# Spelman Dashboard Developer Docs
+
+## Hello!
+
+And welcome to the Spelman Dashboard developer documentation! We're glad you're here :)

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -1,0 +1,5 @@
+site_name: Spelman Dashboard Developer Docs
+repo_url: https://github.com/Spelman-College/spelman-dashboard
+edit_uri: edit/main/docs
+theme: material
+dev_addr: '0.0.0.0:4627'


### PR DESCRIPTION
This creates our docs site for developer documentation. It will generate a static site using mkdocs on push to `main`, which will then be served at `spelman-college.github.io/spelman-dashboard`. Once we have a domain name, we can set up a subdomain to point to this URL.