### PR TITLE
Add a Getting Started page

### DIFF
--- a/docs/docs/getting-started.md
+++ b/docs/docs/getting-started.md
@@ -1,0 +1,28 @@
+# Getting Started
+
+## Prerequisites
+
+1. [Install Docker](https://docs.docker.com/engine/install/).
+
+## Initial Setup
+
+1. Clone this repository and `cd` into it.
+1. Set up your packages for the frontend: `cd frontend` and then `./run-after-changing-packages.sh`. This generates the `node_modules` folder and `package-lock.json` file in a Docker container and copies them locally. This is needed to run the site on your local machine.
+
+## Running a Local Instance of the Dashboard
+
+1. From the root of the repository, `cd frontend`. Then run `docker compose up` to start a local instance of the site.
+1. Navigate to `http://localhost:8080` in your web browser to see the site.
+
+    !!! tip
+
+        As you make changes, you don't need to reload the site. Changes should appear automatically.
+
+## Running a Local Instance of the Documentation Site
+
+1. From the root of the repository, `cd docs`. Then run `docker compose up` to start a local instance of the site.
+1. Navigate to `http://localhost:4627` (the port number spells "D-O-C-S") in your web browser to see the site.
+
+    !!! tip
+
+        As you make changes, you don't need to reload the site. Changes should appear automatically.

--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -3,3 +3,5 @@
 ## Hello!
 
 And welcome to the Spelman Dashboard developer documentation! We're glad you're here :)
+
+Start by checking out our [Getting Started](getting-started.md) guide.

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -3,3 +3,5 @@ repo_url: https://github.com/Spelman-College/spelman-dashboard
 edit_uri: edit/main/docs
 theme: material
 dev_addr: '0.0.0.0:4627'
+markdown_extensions:
+  - admonition


### PR DESCRIPTION
Add a Getting Started page. This also adds the `admonition` extension for the "Tip" box.

This PR will also be used to test doc deployment.