### PR TITLE
Add button to download the current table.

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -8,6 +8,7 @@
       "name": "spelman-dashboard",
       "version": "0.0.0",
       "dependencies": {
+        "@json2csv/plainjs": "^7.0.1",
         "papaparse": "5.4.1",
         "primeflex": "^3.3.1",
         "primevue": "^3.29.2",
@@ -344,9 +345,9 @@
       }
     },
     "node_modules/@esbuild/android-arm": {
-      "version": "0.18.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.18.12.tgz",
-      "integrity": "sha512-LIxaNIQfkFZbTLb4+cX7dozHlAbAshhFE5PKdro0l+FnCpx1GDJaQ2WMcqm+ToXKMt8p8Uojk/MFRuGyz3V5Sw==",
+      "version": "0.18.14",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.18.14.tgz",
+      "integrity": "sha512-blODaaL+lngG5bdK/t4qZcQvq2BBqrABmYwqPPcS5VRxrCSGHb9R/rA3fqxh7R18I7WU4KKv+NYkt22FDfalcg==",
       "cpu": [
         "arm"
       ],
@@ -360,9 +361,9 @@
       }
     },
     "node_modules/@esbuild/android-arm64": {
-      "version": "0.18.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.18.12.tgz",
-      "integrity": "sha512-BMAlczRqC/LUt2P97E4apTBbkvS9JTJnp2DKFbCwpZ8vBvXVbNdqmvzW/OsdtI/+mGr+apkkpqGM8WecLkPgrA==",
+      "version": "0.18.14",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.18.14.tgz",
+      "integrity": "sha512-rZ2v+Luba5/3D6l8kofWgTnqE+qsC/L5MleKIKFyllHTKHrNBMqeRCnZI1BtRx8B24xMYxeU32iIddRQqMsOsg==",
       "cpu": [
         "arm64"
       ],
@@ -376,9 +377,9 @@
       }
     },
     "node_modules/@esbuild/android-x64": {
-      "version": "0.18.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.18.12.tgz",
-      "integrity": "sha512-zU5MyluNsykf5cOJ0LZZZjgAHbhPJ1cWfdH1ZXVMXxVMhEV0VZiZXQdwBBVvmvbF28EizeK7obG9fs+fpmS0eQ==",
+      "version": "0.18.14",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.18.14.tgz",
+      "integrity": "sha512-qSwh8y38QKl+1Iqg+YhvCVYlSk3dVLk9N88VO71U4FUjtiSFylMWK3Ugr8GC6eTkkP4Tc83dVppt2n8vIdlSGg==",
       "cpu": [
         "x64"
       ],
@@ -392,9 +393,9 @@
       }
     },
     "node_modules/@esbuild/darwin-arm64": {
-      "version": "0.18.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.18.12.tgz",
-      "integrity": "sha512-zUZMep7YONnp6954QOOwEBwFX9svlKd3ov6PkxKd53LGTHsp/gy7vHaPGhhjBmEpqXEXShi6dddjIkmd+NgMsA==",
+      "version": "0.18.14",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.18.14.tgz",
+      "integrity": "sha512-9Hl2D2PBeDYZiNbnRKRWuxwHa9v5ssWBBjisXFkVcSP5cZqzZRFBUWEQuqBHO4+PKx4q4wgHoWtfQ1S7rUqJ2Q==",
       "cpu": [
         "arm64"
       ],
@@ -408,9 +409,9 @@
       }
     },
     "node_modules/@esbuild/darwin-x64": {
-      "version": "0.18.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.18.12.tgz",
-      "integrity": "sha512-ohqLPc7i67yunArPj1+/FeeJ7AgwAjHqKZ512ADk3WsE3FHU9l+m5aa7NdxXr0HmN1bjDlUslBjWNbFlD9y12Q==",
+      "version": "0.18.14",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.18.14.tgz",
+      "integrity": "sha512-ZnI3Dg4ElQ6tlv82qLc/UNHtFsgZSKZ7KjsUNAo1BF1SoYDjkGKHJyCrYyWjFecmXpvvG/KJ9A/oe0H12odPLQ==",
       "cpu": [
         "x64"
       ],
@@ -424,9 +425,9 @@
       }
     },
     "node_modules/@esbuild/freebsd-arm64": {
-      "version": "0.18.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.18.12.tgz",
-      "integrity": "sha512-GIIHtQXqgeOOqdG16a/A9N28GpkvjJnjYMhOnXVbn3EDJcoItdR58v/pGN31CHjyXDc8uCcRnFWmqaJt24AYJg==",
+      "version": "0.18.14",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.18.14.tgz",
+      "integrity": "sha512-h3OqR80Da4oQCIa37zl8tU5MwHQ7qgPV0oVScPfKJK21fSRZEhLE4IIVpmcOxfAVmqjU6NDxcxhYaM8aDIGRLw==",
       "cpu": [
         "arm64"
       ],
@@ -440,9 +441,9 @@
       }
     },
     "node_modules/@esbuild/freebsd-x64": {
-      "version": "0.18.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.18.12.tgz",
-      "integrity": "sha512-zK0b9a1/0wZY+6FdOS3BpZcPc1kcx2G5yxxfEJtEUzVxI6n/FrC2Phsxj/YblPuBchhBZ/1wwn7AyEBUyNSa6g==",
+      "version": "0.18.14",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.18.14.tgz",
+      "integrity": "sha512-ha4BX+S6CZG4BoH9tOZTrFIYC1DH13UTCRHzFc3GWX74nz3h/N6MPF3tuR3XlsNjMFUazGgm35MPW5tHkn2lzQ==",
       "cpu": [
         "x64"
       ],
@@ -456,9 +457,9 @@
       }
     },
     "node_modules/@esbuild/linux-arm": {
-      "version": "0.18.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.18.12.tgz",
-      "integrity": "sha512-y75OijvrBE/1XRrXq1jtrJfG26eHeMoqLJ2dwQNwviwTuTtHGCojsDO6BJNF8gU+3jTn1KzJEMETytwsFSvc+Q==",
+      "version": "0.18.14",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.18.14.tgz",
+      "integrity": "sha512-5+7vehI1iqru5WRtJyU2XvTOvTGURw3OZxe3YTdE9muNNIdmKAVmSHpB3Vw2LazJk2ifEdIMt/wTWnVe5V98Kg==",
       "cpu": [
         "arm"
       ],
@@ -472,9 +473,9 @@
       }
     },
     "node_modules/@esbuild/linux-arm64": {
-      "version": "0.18.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.18.12.tgz",
-      "integrity": "sha512-JKgG8Q/LL/9sw/iHHxQyVMoQYu3rU3+a5Z87DxC+wAu3engz+EmctIrV+FGOgI6gWG1z1+5nDDbXiRMGQZXqiw==",
+      "version": "0.18.14",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.18.14.tgz",
+      "integrity": "sha512-IXORRe22In7U65NZCzjwAUc03nn8SDIzWCnfzJ6t/8AvGx5zBkcLfknI+0P+hhuftufJBmIXxdSTbzWc8X/V4w==",
       "cpu": [
         "arm64"
       ],
@@ -488,9 +489,9 @@
       }
     },
     "node_modules/@esbuild/linux-ia32": {
-      "version": "0.18.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.18.12.tgz",
-      "integrity": "sha512-yoRIAqc0B4lDIAAEFEIu9ttTRFV84iuAl0KNCN6MhKLxNPfzwCBvEMgwco2f71GxmpBcTtn7KdErueZaM2rEvw==",
+      "version": "0.18.14",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.18.14.tgz",
+      "integrity": "sha512-BfHlMa0nibwpjG+VXbOoqJDmFde4UK2gnW351SQ2Zd4t1N3zNdmUEqRkw/srC1Sa1DRBE88Dbwg4JgWCbNz/FQ==",
       "cpu": [
         "ia32"
       ],
@@ -504,9 +505,9 @@
       }
     },
     "node_modules/@esbuild/linux-loong64": {
-      "version": "0.18.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.18.12.tgz",
-      "integrity": "sha512-qYgt3dHPVvf/MgbIBpJ4Sup/yb9DAopZ3a2JgMpNKIHUpOdnJ2eHBo/aQdnd8dJ21X/+sS58wxHtA9lEazYtXQ==",
+      "version": "0.18.14",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.18.14.tgz",
+      "integrity": "sha512-j2/Ex++DRUWIAaUDprXd3JevzGtZ4/d7VKz+AYDoHZ3HjJzCyYBub9CU1wwIXN+viOP0b4VR3RhGClsvyt/xSw==",
       "cpu": [
         "loong64"
       ],
@@ -520,9 +521,9 @@
       }
     },
     "node_modules/@esbuild/linux-mips64el": {
-      "version": "0.18.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.18.12.tgz",
-      "integrity": "sha512-wHphlMLK4ufNOONqukELfVIbnGQJrHJ/mxZMMrP2jYrPgCRZhOtf0kC4yAXBwnfmULimV1qt5UJJOw4Kh13Yfg==",
+      "version": "0.18.14",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.18.14.tgz",
+      "integrity": "sha512-qn2+nc+ZCrJmiicoAnJXJJkZWt8Nwswgu1crY7N+PBR8ChBHh89XRxj38UU6Dkthl2yCVO9jWuafZ24muzDC/A==",
       "cpu": [
         "mips64el"
       ],
@@ -536,9 +537,9 @@
       }
     },
     "node_modules/@esbuild/linux-ppc64": {
-      "version": "0.18.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.18.12.tgz",
-      "integrity": "sha512-TeN//1Ft20ZZW41+zDSdOI/Os1bEq5dbvBvYkberB7PHABbRcsteeoNVZFlI0YLpGdlBqohEpjrn06kv8heCJg==",
+      "version": "0.18.14",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.18.14.tgz",
+      "integrity": "sha512-aGzXzd+djqeEC5IRkDKt3kWzvXoXC6K6GyYKxd+wsFJ2VQYnOWE954qV2tvy5/aaNrmgPTb52cSCHFE+Z7Z0yg==",
       "cpu": [
         "ppc64"
       ],
@@ -552,9 +553,9 @@
       }
     },
     "node_modules/@esbuild/linux-riscv64": {
-      "version": "0.18.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.18.12.tgz",
-      "integrity": "sha512-AgUebVS4DoAblBgiB2ACQ/8l4eGE5aWBb8ZXtkXHiET9mbj7GuWt3OnsIW/zX+XHJt2RYJZctbQ2S/mDjbp0UA==",
+      "version": "0.18.14",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.18.14.tgz",
+      "integrity": "sha512-8C6vWbfr0ygbAiMFLS6OPz0BHvApkT2gCboOGV76YrYw+sD/MQJzyITNsjZWDXJwPu9tjrFQOVG7zijRzBCnLw==",
       "cpu": [
         "riscv64"
       ],
@@ -568,9 +569,9 @@
       }
     },
     "node_modules/@esbuild/linux-s390x": {
-      "version": "0.18.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.18.12.tgz",
-      "integrity": "sha512-dJ3Rb3Ei2u/ysSXd6pzleGtfDdc2MuzKt8qc6ls8vreP1G3B7HInX3i7gXS4BGeVd24pp0yqyS7bJ5NHaI9ing==",
+      "version": "0.18.14",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.18.14.tgz",
+      "integrity": "sha512-G/Lf9iu8sRMM60OVGOh94ZW2nIStksEcITkXdkD09/T6QFD/o+g0+9WVyR/jajIb3A0LvBJ670tBnGe1GgXMgw==",
       "cpu": [
         "s390x"
       ],
@@ -584,9 +585,9 @@
       }
     },
     "node_modules/@esbuild/linux-x64": {
-      "version": "0.18.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.18.12.tgz",
-      "integrity": "sha512-OrNJMGQbPaVyHHcDF8ybNSwu7TDOfX8NGpXCbetwOSP6txOJiWlgQnRymfC9ocR1S0Y5PW0Wb1mV6pUddqmvmQ==",
+      "version": "0.18.14",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.18.14.tgz",
+      "integrity": "sha512-TBgStYBQaa3EGhgqIDM+ECnkreb0wkcKqL7H6m+XPcGUoU4dO7dqewfbm0mWEQYH3kzFHrzjOFNpSAVzDZRSJw==",
       "cpu": [
         "x64"
       ],
@@ -600,9 +601,9 @@
       }
     },
     "node_modules/@esbuild/netbsd-x64": {
-      "version": "0.18.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.18.12.tgz",
-      "integrity": "sha512-55FzVCAiwE9FK8wWeCRuvjazNRJ1QqLCYGZVB6E8RuQuTeStSwotpSW4xoRGwp3a1wUsaVCdYcj5LGCASVJmMg==",
+      "version": "0.18.14",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.18.14.tgz",
+      "integrity": "sha512-stvCcjyCQR2lMTroqNhAbvROqRjxPEq0oQ380YdXxA81TaRJEucH/PzJ/qsEtsHgXlWFW6Ryr/X15vxQiyRXVg==",
       "cpu": [
         "x64"
       ],
@@ -616,9 +617,9 @@
       }
     },
     "node_modules/@esbuild/openbsd-x64": {
-      "version": "0.18.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.18.12.tgz",
-      "integrity": "sha512-qnluf8rfb6Y5Lw2tirfK2quZOBbVqmwxut7GPCIJsM8lc4AEUj9L8y0YPdLaPK0TECt4IdyBdBD/KRFKorlK3g==",
+      "version": "0.18.14",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.18.14.tgz",
+      "integrity": "sha512-apAOJF14CIsN5ht1PA57PboEMsNV70j3FUdxLmA2liZ20gEQnfTG5QU0FhENo5nwbTqCB2O3WDsXAihfODjHYw==",
       "cpu": [
         "x64"
       ],
@@ -632,9 +633,9 @@
       }
     },
     "node_modules/@esbuild/sunos-x64": {
-      "version": "0.18.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.18.12.tgz",
-      "integrity": "sha512-+RkKpVQR7bICjTOPUpkTBTaJ4TFqQBX5Ywyd/HSdDkQGn65VPkTsR/pL4AMvuMWy+wnXgIl4EY6q4mVpJal8Kg==",
+      "version": "0.18.14",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.18.14.tgz",
+      "integrity": "sha512-fYRaaS8mDgZcGybPn2MQbn1ZNZx+UXFSUoS5Hd2oEnlsyUcr/l3c6RnXf1bLDRKKdLRSabTmyCy7VLQ7VhGdOQ==",
       "cpu": [
         "x64"
       ],
@@ -648,9 +649,9 @@
       }
     },
     "node_modules/@esbuild/win32-arm64": {
-      "version": "0.18.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.18.12.tgz",
-      "integrity": "sha512-GNHuciv0mFM7ouzsU0+AwY+7eV4Mgo5WnbhfDCQGtpvOtD1vbOiRjPYG6dhmMoFyBjj+pNqQu2X+7DKn0KQ/Gw==",
+      "version": "0.18.14",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.18.14.tgz",
+      "integrity": "sha512-1c44RcxKEJPrVj62XdmYhxXaU/V7auELCmnD+Ri+UCt+AGxTvzxl9uauQhrFso8gj6ZV1DaORV0sT9XSHOAk8Q==",
       "cpu": [
         "arm64"
       ],
@@ -664,9 +665,9 @@
       }
     },
     "node_modules/@esbuild/win32-ia32": {
-      "version": "0.18.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.18.12.tgz",
-      "integrity": "sha512-kR8cezhYipbbypGkaqCTWIeu4zID17gamC8YTPXYtcN3E5BhhtTnwKBn9I0PJur/T6UVwIEGYzkffNL0lFvxEw==",
+      "version": "0.18.14",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.18.14.tgz",
+      "integrity": "sha512-EXAFttrdAxZkFQmpvcAQ2bywlWUsONp/9c2lcfvPUhu8vXBBenCXpoq9YkUvVP639ld3YGiYx0YUQ6/VQz3Maw==",
       "cpu": [
         "ia32"
       ],
@@ -680,9 +681,9 @@
       }
     },
     "node_modules/@esbuild/win32-x64": {
-      "version": "0.18.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.18.12.tgz",
-      "integrity": "sha512-O0UYQVkvfM/jO8a4OwoV0mAKSJw+mjWTAd1MJd/1FCX6uiMdLmMRPK/w6e9OQ0ob2WGxzIm9va/KG0Ja4zIOgg==",
+      "version": "0.18.14",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.18.14.tgz",
+      "integrity": "sha512-K0QjGbcskx+gY+qp3v4/940qg8JitpXbdxFhRDA1aYoNaPff88+aEwoq45aqJ+ogpxQxmU0ZTjgnrQD/w8iiUg==",
       "cpu": [
         "x64"
       ],
@@ -852,6 +853,21 @@
       "integrity": "sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw==",
       "dev": true
     },
+    "node_modules/@json2csv/formatters": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/@json2csv/formatters/-/formatters-7.0.1.tgz",
+      "integrity": "sha512-eCmYKIIoFDXUB0Fotet2RmcoFTtNLXLmSV7j6aEQH/D2GiO749Uan3ts03PtAhXpE11QghxBjS0toXom8VQNBw=="
+    },
+    "node_modules/@json2csv/plainjs": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/@json2csv/plainjs/-/plainjs-7.0.1.tgz",
+      "integrity": "sha512-UAdaZwahrUeYhMYYilJwDsRfE7wDRsmGMsszYH67j8FLD5gZitqG38RXpUgHEH0s6YjsY8iKYWeEQ19WILncFA==",
+      "dependencies": {
+        "@json2csv/formatters": "^7.0.1",
+        "@streamparser/json": "^0.0.15",
+        "lodash.get": "^4.4.2"
+      }
+    },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -892,6 +908,11 @@
       "resolved": "https://registry.npmjs.org/@rushstack/eslint-patch/-/eslint-patch-1.3.2.tgz",
       "integrity": "sha512-V+MvGwaHH03hYhY+k6Ef/xKd6RYlc4q8WBx+2ANmipHJcKuktNcI/NgEsJgdSUF6Lw32njT6OnrRsKYCdgHjYw==",
       "dev": true
+    },
+    "node_modules/@streamparser/json": {
+      "version": "0.0.15",
+      "resolved": "https://registry.npmjs.org/@streamparser/json/-/json-0.0.15.tgz",
+      "integrity": "sha512-6oikjkMTYAHGqKmcC9leE4+kY4Ch4eiTImXUN/N4d2bNGBYs0LJ/tfxmpvF5eExSU7iiPlV9jYlADqvj3NWA3Q=="
     },
     "node_modules/@tsconfig/node18": {
       "version": "2.0.1",
@@ -1227,30 +1248,30 @@
       }
     },
     "node_modules/@volar/language-core": {
-      "version": "1.8.3",
-      "resolved": "https://registry.npmjs.org/@volar/language-core/-/language-core-1.8.3.tgz",
-      "integrity": "sha512-ceWQ7Z1rGs1MwebXqbNTZs6cYMDt2tamy9UIEB5OM4CQFIx8wWtXscLRNYI9T6+1QKDfGblsQW9bnqp8KU/y6g==",
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@volar/language-core/-/language-core-1.9.0.tgz",
+      "integrity": "sha512-+PTRrGanAD2PxqMty0ZC46xhgW5BWzb67RLHhZyB3Im4+eMXsKlYjFUt7Z8ZCwTWQQOnj8NQ6gSgUEoOTwAHrQ==",
       "dev": true,
       "dependencies": {
-        "@volar/source-map": "1.8.3"
+        "@volar/source-map": "1.9.0"
       }
     },
     "node_modules/@volar/source-map": {
-      "version": "1.8.3",
-      "resolved": "https://registry.npmjs.org/@volar/source-map/-/source-map-1.8.3.tgz",
-      "integrity": "sha512-/BeOqhiJhcHjNtxNBVGL8xua9nr4aLI0D1xarI+hN0C8MxRJLBGWZrhgMhEIXYFDzykQsqlxZwt09Iqjv7n32Q==",
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@volar/source-map/-/source-map-1.9.0.tgz",
+      "integrity": "sha512-TQWLY8ozUOHBHTMC2pHZsNbtM25Q9QCEwAL8JFR/gmR9Yv0d9qup/gQdd5sDI7RmoPYKD+gqjLrbM4Ib41QSJQ==",
       "dev": true,
       "dependencies": {
         "muggle-string": "^0.3.1"
       }
     },
     "node_modules/@volar/typescript": {
-      "version": "1.8.3",
-      "resolved": "https://registry.npmjs.org/@volar/typescript/-/typescript-1.8.3.tgz",
-      "integrity": "sha512-PUHlrZjTf+PY97GVH9VPF55Z62lfqBRGCtjSkLKvQsm0kvUK+CgihjUzwx8ABwaeIXgoR5AKPJf9zeqlH3i4hQ==",
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@volar/typescript/-/typescript-1.9.0.tgz",
+      "integrity": "sha512-B8X4/H6V93uD7zu5VCw05eB0Ukcc39SFKsZoeylkAk2sJ50oaJLpajnQ8Ov4c+FnVQ6iPA6Xy1qdWoWJjh6xEg==",
       "dev": true,
       "dependencies": {
-        "@volar/language-core": "1.8.3"
+        "@volar/language-core": "1.9.0"
       }
     },
     "node_modules/@vue/compiler-core": {
@@ -1338,13 +1359,13 @@
       }
     },
     "node_modules/@vue/language-core": {
-      "version": "1.8.4",
-      "resolved": "https://registry.npmjs.org/@vue/language-core/-/language-core-1.8.4.tgz",
-      "integrity": "sha512-pnNtNcJVfkGYluW0vsVO+Y1gyX+eA0voaS7+1JOhCp5zKeCaL/PAmGYOgfvwML62neL+2H8pnhY7sffmrGpEhw==",
+      "version": "1.8.5",
+      "resolved": "https://registry.npmjs.org/@vue/language-core/-/language-core-1.8.5.tgz",
+      "integrity": "sha512-DKQNiNQzNV7nrkZQujvjfX73zqKdj2+KoM4YeKl+ft3f+crO3JB4ycPnmgaRMNX/ULJootdQPGHKFRl5cXxwaw==",
       "dev": true,
       "dependencies": {
-        "@volar/language-core": "~1.8.0",
-        "@volar/source-map": "~1.8.0",
+        "@volar/language-core": "~1.9.0",
+        "@volar/source-map": "~1.9.0",
         "@vue/compiler-dom": "^3.3.0",
         "@vue/reactivity": "^3.3.0",
         "@vue/shared": "^3.3.0",
@@ -1448,13 +1469,13 @@
       "dev": true
     },
     "node_modules/@vue/typescript": {
-      "version": "1.8.4",
-      "resolved": "https://registry.npmjs.org/@vue/typescript/-/typescript-1.8.4.tgz",
-      "integrity": "sha512-sioQfIY5xcmEAz+cPLvv6CtzGPtGhIdR0Za87zB8M4mPe4OSsE3MBGkXcslf+EzQgF+fm6Gr1SRMSX8r5ZmzDA==",
+      "version": "1.8.5",
+      "resolved": "https://registry.npmjs.org/@vue/typescript/-/typescript-1.8.5.tgz",
+      "integrity": "sha512-domFBbNr3PEcjGBeB+cmgUM3cI6pJsJezguIUKZ1rphkfIkICyoMjCd3TitoP32yo2KABLiaXcGFzgFfQf6B3w==",
       "dev": true,
       "dependencies": {
-        "@volar/typescript": "~1.8.0",
-        "@vue/language-core": "1.8.4"
+        "@volar/typescript": "~1.9.0",
+        "@vue/language-core": "1.8.5"
       }
     },
     "node_modules/acorn": {
@@ -1541,6 +1562,26 @@
       "dev": true,
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/arraybuffer.prototype.slice": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/arraybuffer.prototype.slice/-/arraybuffer.prototype.slice-1.0.1.tgz",
+      "integrity": "sha512-09x0ZWFEjj4WD8PDbykUwo3t9arLn8NIzmmYEJFpYekOAQjpkGSyrQhNoRTcwwcFRu+ycWF78QZ63oWTqSjBcw==",
+      "dev": true,
+      "dependencies": {
+        "array-buffer-byte-length": "^1.0.0",
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.2.0",
+        "get-intrinsic": "^1.2.1",
+        "is-array-buffer": "^3.0.2",
+        "is-shared-array-buffer": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/available-typed-arrays": {
@@ -1644,9 +1685,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001515",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001515.tgz",
-      "integrity": "sha512-eEFDwUOZbE24sb+Ecsx3+OvNETqjWIdabMy52oOkIgcUtAsQifjUG9q4U9dgTHJM2mfk4uEPxc0+xuFdJ629QA==",
+      "version": "1.0.30001517",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001517.tgz",
+      "integrity": "sha512-Vdhm5S11DaFVLlyiKu4hiUTkpZu+y1KA/rZZqVQfOD5YdDT/eQKlkt7NaE0WGOFgX32diqt9MiP9CAiFeRklaA==",
       "dev": true,
       "funding": [
         {
@@ -1805,9 +1846,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.4.460",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.460.tgz",
-      "integrity": "sha512-kKiHnbrHME7z8E6AYaw0ehyxY5+hdaRmeUbjBO22LZMdqTYCO29EvF0T1cQ3pJ1RN5fyMcHl1Lmcsdt9WWJpJQ==",
+      "version": "1.4.465",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.465.tgz",
+      "integrity": "sha512-XQcuHvEJRMU97UJ75e170mgcITZoz0lIyiaVjk6R+NMTJ8KBIvUHYd1779swgOppUlzxR+JsLpq59PumaXS1jQ==",
       "dev": true
     },
     "node_modules/error-ex": {
@@ -1820,12 +1861,13 @@
       }
     },
     "node_modules/es-abstract": {
-      "version": "1.21.3",
-      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.21.3.tgz",
-      "integrity": "sha512-ZU4miiY1j3sGPFLJ34VJXEqhpmL+HGByCinGHv4HC+Fxl2fI2Z4yR6tl0mORnDr6PA8eihWo4LmSWDbvhALckg==",
+      "version": "1.22.1",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.22.1.tgz",
+      "integrity": "sha512-ioRRcXMO6OFyRpyzV3kE1IIBd4WG5/kltnzdxSCqoP8CMGs/Li+M1uF5o7lOkZVFjDs+NLesthnF66Pg/0q0Lw==",
       "dev": true,
       "dependencies": {
         "array-buffer-byte-length": "^1.0.0",
+        "arraybuffer.prototype.slice": "^1.0.1",
         "available-typed-arrays": "^1.0.5",
         "call-bind": "^1.0.2",
         "es-set-tostringtag": "^2.0.1",
@@ -1852,10 +1894,13 @@
         "object-keys": "^1.1.1",
         "object.assign": "^4.1.4",
         "regexp.prototype.flags": "^1.5.0",
+        "safe-array-concat": "^1.0.0",
         "safe-regex-test": "^1.0.0",
         "string.prototype.trim": "^1.2.7",
         "string.prototype.trimend": "^1.0.6",
         "string.prototype.trimstart": "^1.0.6",
+        "typed-array-buffer": "^1.0.0",
+        "typed-array-byte-length": "^1.0.0",
         "typed-array-byte-offset": "^1.0.0",
         "typed-array-length": "^1.0.4",
         "unbox-primitive": "^1.0.2",
@@ -1900,9 +1945,9 @@
       }
     },
     "node_modules/esbuild": {
-      "version": "0.18.12",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.18.12.tgz",
-      "integrity": "sha512-XuOVLDdtsDslXStStduT41op21Ytmf4/BDS46aa3xPJ7X5h2eMWBF1oAe3QjUH3bDksocNXgzGUZ7XHIBya6Tg==",
+      "version": "0.18.14",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.18.14.tgz",
+      "integrity": "sha512-uNPj5oHPYmj+ZhSQeYQVFZ+hAlJZbAGOmmILWIqrGvPVlNLbyOvU5Bu6Woi8G8nskcx0vwY0iFoMPrzT86Ko+w==",
       "dev": true,
       "hasInstallScript": true,
       "bin": {
@@ -1912,28 +1957,28 @@
         "node": ">=12"
       },
       "optionalDependencies": {
-        "@esbuild/android-arm": "0.18.12",
-        "@esbuild/android-arm64": "0.18.12",
-        "@esbuild/android-x64": "0.18.12",
-        "@esbuild/darwin-arm64": "0.18.12",
-        "@esbuild/darwin-x64": "0.18.12",
-        "@esbuild/freebsd-arm64": "0.18.12",
-        "@esbuild/freebsd-x64": "0.18.12",
-        "@esbuild/linux-arm": "0.18.12",
-        "@esbuild/linux-arm64": "0.18.12",
-        "@esbuild/linux-ia32": "0.18.12",
-        "@esbuild/linux-loong64": "0.18.12",
-        "@esbuild/linux-mips64el": "0.18.12",
-        "@esbuild/linux-ppc64": "0.18.12",
-        "@esbuild/linux-riscv64": "0.18.12",
-        "@esbuild/linux-s390x": "0.18.12",
-        "@esbuild/linux-x64": "0.18.12",
-        "@esbuild/netbsd-x64": "0.18.12",
-        "@esbuild/openbsd-x64": "0.18.12",
-        "@esbuild/sunos-x64": "0.18.12",
-        "@esbuild/win32-arm64": "0.18.12",
-        "@esbuild/win32-ia32": "0.18.12",
-        "@esbuild/win32-x64": "0.18.12"
+        "@esbuild/android-arm": "0.18.14",
+        "@esbuild/android-arm64": "0.18.14",
+        "@esbuild/android-x64": "0.18.14",
+        "@esbuild/darwin-arm64": "0.18.14",
+        "@esbuild/darwin-x64": "0.18.14",
+        "@esbuild/freebsd-arm64": "0.18.14",
+        "@esbuild/freebsd-x64": "0.18.14",
+        "@esbuild/linux-arm": "0.18.14",
+        "@esbuild/linux-arm64": "0.18.14",
+        "@esbuild/linux-ia32": "0.18.14",
+        "@esbuild/linux-loong64": "0.18.14",
+        "@esbuild/linux-mips64el": "0.18.14",
+        "@esbuild/linux-ppc64": "0.18.14",
+        "@esbuild/linux-riscv64": "0.18.14",
+        "@esbuild/linux-s390x": "0.18.14",
+        "@esbuild/linux-x64": "0.18.14",
+        "@esbuild/netbsd-x64": "0.18.14",
+        "@esbuild/openbsd-x64": "0.18.14",
+        "@esbuild/sunos-x64": "0.18.14",
+        "@esbuild/win32-arm64": "0.18.14",
+        "@esbuild/win32-ia32": "0.18.14",
+        "@esbuild/win32-x64": "0.18.14"
       }
     },
     "node_modules/escalade": {
@@ -1955,9 +2000,9 @@
       }
     },
     "node_modules/eslint": {
-      "version": "8.44.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.44.0.tgz",
-      "integrity": "sha512-0wpHoUbDUHgNCyvFB5aXLiQVfK9B0at6gUvzy83k4kAsQ/u769TQDX6iKC+aO4upIHO9WSaA3QoXYQDHbNwf1A==",
+      "version": "8.45.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.45.0.tgz",
+      "integrity": "sha512-pd8KSxiQpdYRfYa9Wufvdoct3ZPQQuVuU5O6scNgMuOMYuxvH0IGaYK0wUFjo4UYYQQCUndlXiMbnxopwvvTiw==",
       "dev": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
@@ -1985,7 +2030,6 @@
         "globals": "^13.19.0",
         "graphemer": "^1.4.0",
         "ignore": "^5.2.0",
-        "import-fresh": "^3.0.0",
         "imurmurhash": "^0.1.4",
         "is-glob": "^4.0.0",
         "is-path-inside": "^3.0.3",
@@ -1997,7 +2041,6 @@
         "natural-compare": "^1.4.0",
         "optionator": "^0.9.3",
         "strip-ansi": "^6.0.1",
-        "strip-json-comments": "^3.1.0",
         "text-table": "^0.2.0"
       },
       "bin": {
@@ -2184,9 +2227,9 @@
       }
     },
     "node_modules/eslint/node_modules/eslint-scope": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-7.2.0.tgz",
-      "integrity": "sha512-DYj5deGlHBfMt15J7rdtyKNq/Nqlv5KfU4iodrQ019XESsRnwXH9KAE0y3cwtUHDo2ob7CypAnCqefh6vioWRw==",
+      "version": "7.2.1",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-7.2.1.tgz",
+      "integrity": "sha512-CvefSOsDdaYYvxChovdrPo/ZGt8d5lrJWleAc1diXRKhHGiTYEI26cvo8Kle/wGnsizoCJjK73FMg1/IkIwiNA==",
       "dev": true,
       "dependencies": {
         "esrecurse": "^4.3.0",
@@ -2245,9 +2288,9 @@
       }
     },
     "node_modules/espree": {
-      "version": "9.6.0",
-      "resolved": "https://registry.npmjs.org/espree/-/espree-9.6.0.tgz",
-      "integrity": "sha512-1FH/IiruXZ84tpUlm0aCUEwMl2Ho5ilqVh0VvQXw+byAz/4SAciyHLlfmL5WYqsvD38oymdUwBss0LtK8m4s/A==",
+      "version": "9.6.1",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-9.6.1.tgz",
+      "integrity": "sha512-oruZaFkjorTpF32kDSI5/75ViwGeZginGGy2NoOSg3Q9bnwlnmDm4HLnkl0RE3n+njDXR037aY1+x58Z/zFdwQ==",
       "dev": true,
       "dependencies": {
         "acorn": "^8.9.0",
@@ -3020,16 +3063,12 @@
       }
     },
     "node_modules/is-typed-array": {
-      "version": "1.1.10",
-      "resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.10.tgz",
-      "integrity": "sha512-PJqgEHiWZvMpaFZ3uTc8kHPM4+4ADTlDniuQL7cU/UDA0Ql7F70yGfHph3cLNe+c9toaigv+DFzTJKhc2CtO6A==",
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.12.tgz",
+      "integrity": "sha512-Z14TF2JNG8Lss5/HMqt0//T9JeHXttXy5pH/DBU4vi98ozO2btxzq9MwYDZYnKwU8nRsz/+GVFVRDq3DkVuSPg==",
       "dev": true,
       "dependencies": {
-        "available-typed-arrays": "^1.0.5",
-        "call-bind": "^1.0.2",
-        "for-each": "^0.3.3",
-        "gopd": "^1.0.1",
-        "has-tostringtag": "^1.0.0"
+        "which-typed-array": "^1.1.11"
       },
       "engines": {
         "node": ">= 0.4"
@@ -3049,6 +3088,12 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/isarray": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
+      "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
+      "dev": true
     },
     "node_modules/isexe": {
       "version": "2.0.0",
@@ -3164,6 +3209,11 @@
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
       "dev": true
+    },
+    "node_modules/lodash.get": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
+      "integrity": "sha512-z+Uw/vLuy6gQe8cfaFWD7p0wVv8fJl3mbzXh33RS+0oW2wvUqiRXiQ69gLWSLpgB5/6sU+r6BlQR0MBILadqTQ=="
     },
     "node_modules/lodash.merge": {
       "version": "4.6.2",
@@ -3696,9 +3746,9 @@
       "integrity": "sha512-zaOq3YvcOYytbAmKv3zYc+0VNS9Wg5d37dfxZnveKBFPr7vEIwfV5ydrpiouTft8MVW6qNjfkaQphHSnvgQbpQ=="
     },
     "node_modules/primevue": {
-      "version": "3.30.0",
-      "resolved": "https://registry.npmjs.org/primevue/-/primevue-3.30.0.tgz",
-      "integrity": "sha512-BPMCtfEQIRfD4rrYpoRfPDWnMgrWZ7tTciKn98C1jtDxsIr7pMeNpIC2kS8x+1Jz33wqn74fi03TYo7WgJJFtA==",
+      "version": "3.30.1",
+      "resolved": "https://registry.npmjs.org/primevue/-/primevue-3.30.1.tgz",
+      "integrity": "sha512-mYn23hG5glj3iN7cCC5nhsA7Gn7Na8gtr8BpNPF+3hxZwWPZAsPTLVLkPDYriIefqnKDzfN7f8TmeetMygDsJg==",
       "peerDependencies": {
         "vue": "^3.0.0"
       }
@@ -3827,9 +3877,9 @@
       }
     },
     "node_modules/rollup": {
-      "version": "3.26.2",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-3.26.2.tgz",
-      "integrity": "sha512-6umBIGVz93er97pMgQO08LuH3m6PUb3jlDUUGFsNJB6VgTCUaDFpupf5JfU30529m/UKOgmiX+uY6Sx8cOYpLA==",
+      "version": "3.26.3",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-3.26.3.tgz",
+      "integrity": "sha512-7Tin0C8l86TkpcMtXvQu6saWH93nhG3dGQ1/+l5V2TDMceTxO7kDiK6GzbfLWNNxqJXm591PcEZUozZm51ogwQ==",
       "dev": true,
       "bin": {
         "rollup": "dist/bin/rollup"
@@ -3863,6 +3913,24 @@
       ],
       "dependencies": {
         "queue-microtask": "^1.2.2"
+      }
+    },
+    "node_modules/safe-array-concat": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/safe-array-concat/-/safe-array-concat-1.0.0.tgz",
+      "integrity": "sha512-9dVEFruWIsnie89yym+xWTAYASdpw3CJV7Li/6zBewGf9z2i1j31rP6jnY0pHEO4QZh6N0K11bFjWmdR8UGdPQ==",
+      "dev": true,
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "get-intrinsic": "^1.2.0",
+        "has-symbols": "^1.0.3",
+        "isarray": "^2.0.5"
+      },
+      "engines": {
+        "node": ">=0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/safe-regex-test": {
@@ -4172,6 +4240,38 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/typed-array-buffer": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/typed-array-buffer/-/typed-array-buffer-1.0.0.tgz",
+      "integrity": "sha512-Y8KTSIglk9OZEr8zywiIHG/kmQ7KWyjseXs1CbSo8vC42w7hg2HgYTxSWwP0+is7bWDc1H+Fo026CpHFwm8tkw==",
+      "dev": true,
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "get-intrinsic": "^1.2.1",
+        "is-typed-array": "^1.1.10"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/typed-array-byte-length": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/typed-array-byte-length/-/typed-array-byte-length-1.0.0.tgz",
+      "integrity": "sha512-Or/+kvLxNpeQ9DtSydonMxCx+9ZXOswtwJn17SNLvhptaXYDJvkFFP5zbfU/uLmvnBJlI4yrnXRxpdWH/M5tNA==",
+      "dev": true,
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "for-each": "^0.3.3",
+        "has-proto": "^1.0.1",
+        "is-typed-array": "^1.1.10"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/typed-array-byte-offset": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/typed-array-byte-offset/-/typed-array-byte-offset-1.0.0.tgz",
@@ -4289,9 +4389,9 @@
       }
     },
     "node_modules/vite": {
-      "version": "4.4.3",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-4.4.3.tgz",
-      "integrity": "sha512-IMnXQXXWgLi5brBQx/4WzDxdzW0X3pjO4nqFJAuNvwKtxzAmPzFE1wszW3VDpAGQJm3RZkm/brzRdyGsnwgJIA==",
+      "version": "4.4.4",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-4.4.4.tgz",
+      "integrity": "sha512-4mvsTxjkveWrKDJI70QmelfVqTm+ihFAb6+xf4sjEU2TmUCTlVX87tmg/QooPEMQb/lM9qGHT99ebqPziEd3wg==",
       "dev": true,
       "dependencies": {
         "esbuild": "^0.18.10",
@@ -4380,9 +4480,9 @@
       }
     },
     "node_modules/vue-eslint-parser/node_modules/eslint-scope": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-7.2.0.tgz",
-      "integrity": "sha512-DYj5deGlHBfMt15J7rdtyKNq/Nqlv5KfU4iodrQ019XESsRnwXH9KAE0y3cwtUHDo2ob7CypAnCqefh6vioWRw==",
+      "version": "7.2.1",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-7.2.1.tgz",
+      "integrity": "sha512-CvefSOsDdaYYvxChovdrPo/ZGt8d5lrJWleAc1diXRKhHGiTYEI26cvo8Kle/wGnsizoCJjK73FMg1/IkIwiNA==",
       "dev": true,
       "dependencies": {
         "esrecurse": "^4.3.0",
@@ -4448,13 +4548,13 @@
       }
     },
     "node_modules/vue-tsc": {
-      "version": "1.8.4",
-      "resolved": "https://registry.npmjs.org/vue-tsc/-/vue-tsc-1.8.4.tgz",
-      "integrity": "sha512-+hgpOhIx11vbi8/AxEdaPj3fiRwN9wy78LpsNNw2V995/IWa6TMyQxHbaw2ZKUpdwjySSHgrT6ohDEhUgFxGYw==",
+      "version": "1.8.5",
+      "resolved": "https://registry.npmjs.org/vue-tsc/-/vue-tsc-1.8.5.tgz",
+      "integrity": "sha512-Jr8PTghJIwp69MFsEZoADDcv2l+lXA8juyN/5AYA5zxyZNvIHjSbgKgkYIYc1qnihrOyIG1VOnfk4ZE0jqn8bw==",
       "dev": true,
       "dependencies": {
-        "@vue/language-core": "1.8.4",
-        "@vue/typescript": "1.8.4",
+        "@vue/language-core": "1.8.5",
+        "@vue/typescript": "1.8.5",
         "semver": "^7.3.8"
       },
       "bin": {
@@ -4529,17 +4629,16 @@
       }
     },
     "node_modules/which-typed-array": {
-      "version": "1.1.10",
-      "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.10.tgz",
-      "integrity": "sha512-uxoA5vLUfRPdjCuJ1h5LlYdmTLbYfums398v3WLkM+i/Wltl2/XyZpQWKbN++ck5L64SR/grOHqtXCUKmlZPNA==",
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.11.tgz",
+      "integrity": "sha512-qe9UWWpkeG5yzZ0tNYxDmd7vo58HDBc39mZ0xWWpolAGADdFOzkfamWLDxkOWcvHQKVmdTyQdLD4NOfjLWTKew==",
       "dev": true,
       "dependencies": {
         "available-typed-arrays": "^1.0.5",
         "call-bind": "^1.0.2",
         "for-each": "^0.3.3",
         "gopd": "^1.0.1",
-        "has-tostringtag": "^1.0.0",
-        "is-typed-array": "^1.1.10"
+        "has-tostringtag": "^1.0.0"
       },
       "engines": {
         "node": ">= 0.4"

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -12,6 +12,7 @@
     "format": "prettier --write src/"
   },
   "dependencies": {
+    "@json2csv/plainjs": "^7.0.1",
     "papaparse": "5.4.1",
     "primeflex": "^3.3.1",
     "primevue": "^3.29.2",

--- a/frontend/src/components/DataDashboard.vue
+++ b/frontend/src/components/DataDashboard.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { ref, watchEffect } from 'vue';
 import { Parser } from '@json2csv/plainjs';
+import { setMaxIdleHTTPParsers } from 'http';
 
 const tableItems = ref(Array.from({ length: 5 }));
 const gender = ref("Males");
@@ -16,7 +17,10 @@ const tableCols = [
   }
 ]
 
-const downloadCSV = (gender) => {
+const loading_download = ref(false);
+
+const downloadCSV = async (gender) => {
+  loading_download.value = true;
   try {
     const parser_opts = {};
     const parser = new Parser(parser_opts);
@@ -30,6 +34,7 @@ const downloadCSV = (gender) => {
   } catch (err) {
     console.log(err);
   }
+  loading_download.value = false;
 }
 
 let apiCache = new ApiCache();
@@ -68,7 +73,7 @@ watchEffect(async () => {
 
 
 <template>
-  <div><Button label="Download CSV" @click=downloadCSV(gender) /></div>
+  <div><Button label="Download CSV" @click=downloadCSV(gender) :loading="loading_download" /></div>
   <span>Show US Population with a Bachelor's Degree for: {{ gender }}</span>
 
   <div class="p-field-radiobutton">

--- a/frontend/src/components/DataDashboard.vue
+++ b/frontend/src/components/DataDashboard.vue
@@ -19,7 +19,7 @@ const tableCols = [
 
 const loading_download = ref(false);
 
-const downloadCSV = async (gender) => {
+const downloadCSV = (gender) => {
   loading_download.value = true;
   try {
     const parser_opts = {};

--- a/frontend/src/components/DataDashboard.vue
+++ b/frontend/src/components/DataDashboard.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { ref, watchEffect } from 'vue';
+import { Parser } from '@json2csv/plainjs';
 
 const tableItems = ref(Array.from({ length: 5 }));
 const gender = ref("Males");
@@ -15,9 +16,25 @@ const tableCols = [
   }
 ]
 
+const downloadCSV = (gender) => {
+  try {
+    const parser_opts = {};
+    const parser = new Parser(parser_opts);
+    const csv = parser.parse(tableItems.value);
+    const blob = new Blob([csv], { type: 'text/csv' });
+    const url = window.URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.setAttribute('href', url);
+    a.setAttribute('download', genderToDcid(gender) + '.csv');
+    a.click();
+  } catch (err) {
+    console.log(err);
+  }
+}
+
 let apiCache = new ApiCache();
 
-async function getData(dcid : string) {
+async function getData(dcid: string) {
 
   // This uses DataCommons' public API key. DO NOT INCLUDE A PRIVATE API KEY HERE!
   let request = "https://api.datacommons.org/v1/observations/series/country/USA/" + dcid + "?key=AIzaSyCTI4Xz-UW_G2Q2RfknhcfdAnTHq5X5XuI";
@@ -44,13 +61,14 @@ function genderToDcid(gender: string): string {
   return dcid == undefined ? "" : dcid;
 }
 
- watchEffect(async () => {                                                                                                                                                                                           
-     getData(genderToDcid(gender.value))                                                                                                                                                                             
- }) 
+watchEffect(async () => {
+  getData(genderToDcid(gender.value))
+}) 
 </script>
 
 
 <template>
+  <div><Button label="Download CSV" @click=downloadCSV(gender) /></div>
   <span>Show US Population with a Bachelor's Degree for: {{ gender }}</span>
 
   <div class="p-field-radiobutton">
@@ -81,24 +99,24 @@ export default {
 };
 
 type CacheResult = any;
- 
-export class ApiCache {
-    private static instance: ApiCache;
-    private cache: Map<string, any> = new Map();
- 
-    public set = (url: string, result: any): void => {
-        if (!this.recordExists(url)) {
-          this.cache.set(url, result);
-        }
-    }
- 
-    public get = (url: string): CacheResult | null => {
-        return this.cache.get(url);
 
+export class ApiCache {
+  private static instance: ApiCache;
+  private cache: Map<string, any> = new Map();
+
+  public set = (url: string, result: any): void => {
+    if (!this.recordExists(url)) {
+      this.cache.set(url, result);
     }
-    
-    public recordExists = (url: string): boolean => {
-        return !!this.cache.has(url);
-    }
+  }
+
+  public get = (url: string): CacheResult | null => {
+    return this.cache.get(url);
+
+  }
+
+  public recordExists = (url: string): boolean => {
+    return !!this.cache.has(url);
+  }
 }
 </script>


### PR DESCRIPTION
Additionally adds the [json2csv](https://juanjodiaz.github.io/json2csv/#/) package to convert JSON to CSV. Note we use the blocking version of the parser for simplicity, but json2csv does offer an async version called StreamParser. This seems unnecessary unless the data sets get into the thousands of rows.

The download button enters a [loading state](https://juanjodiaz.github.io/json2csv/#/) which likely can only be seen if an artificial delay is added. It disables the button and adds a loading icon until the download has started. I tested it by adding an artificial delay and it worked as expected.

Originally we discussed not having this as part of the first demo cut, but it ended up being simpler than expected. If we still don't want it to be part of the demo cut, we can delay merging this to main until we make the cut.