### PR TITLE
Update organization cards to use links and images instead of founders.

### DIFF
--- a/frontend/src/components/Organization.vue
+++ b/frontend/src/components/Organization.vue
@@ -5,9 +5,7 @@
      label: props.org.name,
      children: [
 	 { key: props.idx + '-0', label: props.org.website},
-	 { key: props.idx + '-1', label: 'Founded: ' + props.org.founded},
-	 { key: props.idx + '-2', label: 'Founder: ' + props.org.founder},
-	 { key: props.idx + '-3', label: 'STEM Focus: ' + props.org.focus}
+	 { key: props.idx + '-1', label: props.org.info}
      ]
  }]
 </script>
@@ -16,4 +14,10 @@
     <p>
 	<Tree :value="nodes"></Tree>
     </p>
+    <!-- TODO: Integrate image in nodes var -->
+    <Card style="width: 20em; margin-top: 1em; ">
+    <template #header>
+        <img alt="{{props.org.name}}" :src="props.org.image" style="width: 20em;"/>
+	</template>
+    </Card>
 </template>


### PR DESCRIPTION
Updated spreadsheet schema to match mocks and populated spreadsheet with real values.

Spreadsheet: https://docs.google.com/spreadsheets/d/1Vp57HDXod3FgP2aZzDNvYYRBNgPbvNsqqxNJ2b-daoc/edit#gid=0
Mocks: https://www.figma.com/file/wYUjcxSWGv71kfffrJHs5G/Spelman-Project?type=design&node-id=2013-9683&mode=design&t=2ADlVWpA0OdXyjEC-0

Ideally the images will be better integrated into each card as in the mocks; marked as TODO in code.

![Screenshot 2023-08-10 12 45 15 PM](https://github.com/Spelman-College/spelman-dashboard/assets/13266735/6934f521-e030-4739-9271-e1cfd3938bb2)
