### PR TITLE
Use absolute paths for images

### DIFF
--- a/frontend/src/home/MoreToExplore.vue
+++ b/frontend/src/home/MoreToExplore.vue
@@ -3,19 +3,19 @@ import ExploreCard from '@/components/ExploreCard.vue'
 
 const cards = [
   {
-    imgSrc: "data_dashboard_icon.svg",
+    imgSrc: "/data_dashboard_icon.svg",
     header: "Data Dashboard",
     text: "See the comprehensive and informative data dashboard, presenting data in a visually engaging and digestible format",
     link: "Explore data dashboard"
   },
   {
-    imgSrc: "articles_icon.svg",
+    imgSrc: "/articles_icon.svg",
     header: "Articles",
     text: "See the comprehensive and informative data dashboard, presenting data in a visually engaging and digestible format",
     link: "Read articles"
   },
   {
-    imgSrc: "news_icon.svg",
+    imgSrc: "/news_icon.svg",
     header: "News",
     text: "See the comprehensive and informative data dashboard, presenting data in a visually engaging and digestible format",
     link: "Get the latest news"

--- a/frontend/src/home/Stat.vue
+++ b/frontend/src/home/Stat.vue
@@ -8,7 +8,7 @@
         representation, improving access to<br />
         resources and strengthening<br />
         community partnerships.</p>
-      <div id="swiggle"><img src="swiggly_line_ACF0FF.svg" /></div>
+      <div id="swiggle"><img src="/swiggly_line_ACF0FF.svg" /></div>
       <p id="footnote">In 2021, only 2.9% of the STEM workforce in the<br />
         US are Black women.</p>
     </div>

--- a/frontend/src/home/Stories.vue
+++ b/frontend/src/home/Stories.vue
@@ -23,32 +23,32 @@ const stories = [
   {
     name: "Dr. Helene D. Gayle, President of Spelman College",
     story: "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aliquam pharetra quam sed purus dignissim accumsan. Phasellus tristique dignissim lacus, ut dapibus libero luctus a. Sed tempor placerat nulla. Vestibulum tincidunt, massa quis vehicula eleifend, quam felis consectetur libero, vitae volutpat arcu felis eget metus. Nullam laoreet hendrerit mauris vitae ultricies. Vivamus hendrerit erat eget felis hendrerit pulvinar. Integer ut lorem consectetur, auctor nibh a, aliquam sem. Nam erat purus, congue vitae tellus ullamcorper, porttitor pellentesque lectus. Proin sed posuere eros. Phasellus at suscipit nunc, vel maximus tellus. Vestibulum lorem nisi, dapibus malesuada metus id, lacinia ultricies magna. Aenean iaculis ante est, ac euismod dolor vehicula non.",
-    imgSrc: "story_placeholder1.jpg"
+    imgSrc: "/story_placeholder1.jpg"
   },
   {
     name: "Shakiyla Huggins - Meeting the Challenge",
     story: "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aliquam pharetra quam sed purus dignissim accumsan. Phasellus tristique dignissim lacus, ut dapibus libero luctus a. Sed tempor placerat nulla. Vestibulum tincidunt, massa quis vehicula eleifend, quam felis consectetur libero, vitae volutpat arcu felis eget metus. Nullam laoreet hendrerit mauris vitae ultricies. Vivamus hendrerit erat eget felis hendrerit pulvinar. Integer ut lorem consectetur, auctor nibh a, aliquam sem. Nam erat purus, congue vitae tellus ullamcorper, porttitor pellentesque lectus. Proin sed posuere eros. Phasellus at suscipit nunc, vel maximus tellus. Vestibulum lorem nisi, dapibus malesuada metus id, lacinia ultricies magna. Aenean iaculis ante est, ac euismod dolor vehicula non.",
-    imgSrc: "story_placeholder2.jpg"
+    imgSrc: "/story_placeholder2.jpg"
   },
   {
     name: "Deanna Clemmer - An Invaluable Lab",
     story: "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aliquam pharetra quam sed purus dignissim accumsan. Phasellus tristique dignissim lacus, ut dapibus libero luctus a. Sed tempor placerat nulla. Vestibulum tincidunt, massa quis vehicula eleifend, quam felis consectetur libero, vitae volutpat arcu felis eget metus. Nullam laoreet hendrerit mauris vitae ultricies. Vivamus hendrerit erat eget felis hendrerit pulvinar. Integer ut lorem consectetur, auctor nibh a, aliquam sem. Nam erat purus, congue vitae tellus ullamcorper, porttitor pellentesque lectus. Proin sed posuere eros. Phasellus at suscipit nunc, vel maximus tellus. Vestibulum lorem nisi, dapibus malesuada metus id, lacinia ultricies magna. Aenean iaculis ante est, ac euismod dolor vehicula non.",
-    imgSrc: "story_placeholder3.jpg"
+    imgSrc: "/story_placeholder3.jpg"
   },
   {
     name: "4",
     story: "Story 4",
-    imgSrc: "story_placeholder1.jpg"
+    imgSrc: "/story_placeholder1.jpg"
   },
   {
     name: "5",
     story: "Story 5",
-    imgSrc: "story_placeholder2.jpg"
+    imgSrc: "/story_placeholder2.jpg"
   },
   {
     name: "6",
     story: "Story 6",
-    imgSrc: "story_placeholder3.jpg"
+    imgSrc: "/story_placeholder3.jpg"
   },
 ]
 

--- a/frontend/src/views/StoriesView.vue
+++ b/frontend/src/views/StoriesView.vue
@@ -6,32 +6,32 @@ const stories = [
   {
     name: "Dr. Helene D. Gayle, President of Spelman College",
     story: "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aliquam pharetra quam sed purus dignissim accumsan. Phasellus tristique dignissim lacus, ut dapibus libero luctus a. Sed tempor placerat nulla. Vestibulum tincidunt, massa quis vehicula eleifend, quam felis consectetur libero, vitae volutpat arcu felis eget metus. Nullam laoreet hendrerit mauris vitae ultricies. Vivamus hendrerit erat eget felis hendrerit pulvinar. Integer ut lorem consectetur, auctor nibh a, aliquam sem. Nam erat purus, congue vitae tellus ullamcorper, porttitor pellentesque lectus. Proin sed posuere eros. Phasellus at suscipit nunc, vel maximus tellus. Vestibulum lorem nisi, dapibus malesuada metus id, lacinia ultricies magna. Aenean iaculis ante est, ac euismod dolor vehicula non.",
-    imgSrc: "story_placeholder1.jpg"
+    imgSrc: "/story_placeholder1.jpg"
   },
   {
     name: "Shakiyla Huggins - Meeting the Challenge",
     story: "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aliquam pharetra quam sed purus dignissim accumsan. Phasellus tristique dignissim lacus, ut dapibus libero luctus a. Sed tempor placerat nulla. Vestibulum tincidunt, massa quis vehicula eleifend, quam felis consectetur libero, vitae volutpat arcu felis eget metus. Nullam laoreet hendrerit mauris vitae ultricies. Vivamus hendrerit erat eget felis hendrerit pulvinar. Integer ut lorem consectetur, auctor nibh a, aliquam sem. Nam erat purus, congue vitae tellus ullamcorper, porttitor pellentesque lectus. Proin sed posuere eros. Phasellus at suscipit nunc, vel maximus tellus. Vestibulum lorem nisi, dapibus malesuada metus id, lacinia ultricies magna. Aenean iaculis ante est, ac euismod dolor vehicula non.",
-    imgSrc: "story_placeholder2.jpg"
+    imgSrc: "/story_placeholder2.jpg"
   },
   {
     name: "Deanna Clemmer - An Invaluable Lab",
     story: "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aliquam pharetra quam sed purus dignissim accumsan. Phasellus tristique dignissim lacus, ut dapibus libero luctus a. Sed tempor placerat nulla. Vestibulum tincidunt, massa quis vehicula eleifend, quam felis consectetur libero, vitae volutpat arcu felis eget metus. Nullam laoreet hendrerit mauris vitae ultricies. Vivamus hendrerit erat eget felis hendrerit pulvinar. Integer ut lorem consectetur, auctor nibh a, aliquam sem. Nam erat purus, congue vitae tellus ullamcorper, porttitor pellentesque lectus. Proin sed posuere eros. Phasellus at suscipit nunc, vel maximus tellus. Vestibulum lorem nisi, dapibus malesuada metus id, lacinia ultricies magna. Aenean iaculis ante est, ac euismod dolor vehicula non.",
-    imgSrc: "story_placeholder3.jpg"
+    imgSrc: "/story_placeholder3.jpg"
   },
   {
     name: "4",
     story: "Story 4",
-    imgSrc: "story_placeholder1.jpg"
+    imgSrc: "/story_placeholder1.jpg"
   },
   {
     name: "5",
     story: "Story 5",
-    imgSrc: "story_placeholder2.jpg"
+    imgSrc: "/story_placeholder2.jpg"
   },
   {
     name: "6",
     story: "Story 6",
-    imgSrc: "story_placeholder3.jpg"
+    imgSrc: "/story_placeholder3.jpg"
   },
 ]
 </script>


### PR DESCRIPTION
The `src` attribute for `img` tags requires an absolute path (starting with a `/`) when referencing images in the `public` folder. Otherwise the build breaks and images also cannot be accessed on subpages.