### PR TITLE
Access individual story views from homepage carousel

### DIFF
--- a/frontend/src/home/Stories.vue
+++ b/frontend/src/home/Stories.vue
@@ -53,7 +53,7 @@ const page = ref(0)
           <template #name>{{ slotProps.data.name }}</template>
           <template #profession>{{ slotProps.data.profession }}</template>
           <template #story>{{ slotProps.data.how_did_you_choose_this_path }}</template>
-          <template #linkText><router-link :to="{path: '/stories/' + index}">Read her story</router-link></template>
+          <template #linkText><router-link :to="{path: '/stories/' + slotProps.index}">Read her story</router-link></template>
         </StoryCard>
       </template>
     </Carousel>

--- a/frontend/src/home/Stories.vue
+++ b/frontend/src/home/Stories.vue
@@ -53,7 +53,7 @@ const page = ref(0)
           <template #name>{{ slotProps.data.name }}</template>
           <template #profession>{{ slotProps.data.profession }}</template>
           <template #story>{{ slotProps.data.how_did_you_choose_this_path }}</template>
-          <template #linkText><router-link :to="{path: '/stories/' + slotProps.index}">Read her story</router-link></template>
+          <template #linkText><router-link :to="{path: '/stories/' + slotProps.index}">Read her story<span class="material-symbols-outlined">arrow_right_alt</span></router-link></template>
         </StoryCard>
       </template>
     </Carousel>
@@ -81,4 +81,23 @@ const page = ref(0)
 .hidden {
   visibility: hidden;
 }
+
+a {
+  color: #313B49;
+  font-family: Noto Sans Mono;
+  font-size: 1.3125rem;
+  font-style: normal;
+  font-weight: 700;
+  line-height: 1.875rem; /* 142.857% */
+}
+
+.material-symbols-outlined {
+  width: 1.5rem;
+  height: 1.5rem;
+  flex-shrink: 0;
+  color: #313B49;
+  margin-left: 0.81rem;
+  vertical-align:middle;
+}
+
 </style>

--- a/frontend/src/router/index.ts
+++ b/frontend/src/router/index.ts
@@ -12,6 +12,10 @@ import DDWelcomeView from '@/views/dataDashboardViews/DDWelcomeView.vue'
 
 const router = createRouter({
   history: createWebHistory(import.meta.env.BASE_URL),
+  scrollBehavior () {
+  // Always scroll to top
+  return { top: 0 }
+  },
   routes: [
     {
       path: '/',

--- a/frontend/src/views/IndividualStoryView.vue
+++ b/frontend/src/views/IndividualStoryView.vue
@@ -1,10 +1,11 @@
 <script setup lang="ts">
 import Stories from '@/home/Stories.vue'
-import { useRoute } from 'vue-router';
-import { ref, onMounted } from 'vue';
+import { useRoute, useRouter } from 'vue-router';
+import { ref, onMounted, watch } from 'vue';
 import { getData } from '@/sheets/client'
 
 const route = useRoute();
+const router = useRouter();
 
 const sid = import.meta.env.VITE_WOMEN_CONTENT_SHEET_ID
 
@@ -17,6 +18,14 @@ onMounted(() => {
     thisStory.value = data[parseInt(route.params.id)];
 	 })
 });
+
+// TODO: Look into alternate function to speed this up
+watch(route, () => { 
+  const pout = getData(StoriesURI);
+  pout.then((data) => {
+    thisStory.value = data[parseInt(route.params.id)];
+	 }) 
+})
 
 </script>
 


### PR DESCRIPTION
When clicking on a homepage carousel card (`/home/Stories.vue component`), users are now directed to the corrresponding individual view (`localhost:8080/stories/{num}`; `views/IndividualStoryView.vue`). 

Note: 
When clicking on a carousel card from an individual view, the URL is updated appropriately but the user was not redirected. `IndividualStoryView.vue` uses the same `Stories.vue` component as the homepage carousel, but AFAICT IndividualStoryView needs its own route watcher. I got one working, but there's a bit of a lag, so we should look into quicker options. Filed #110 .
