### PR TITLE
[XS] Fix header link to data dashboard.

### DIFF
--- a/frontend/src/router/index.ts
+++ b/frontend/src/router/index.ts
@@ -58,6 +58,7 @@ const router = createRouter({
     },
     {
       path: '/data',
+      name: 'data',
       redirect: '/data-dashboard'
     },
     {


### PR DESCRIPTION
The `/data` path was unnamed in `router/index.ts`, and the header was attempting to use `router.push({ name: 'data' })`.