### PR TITLE
Bring landing page and about page closer to mocks.

### DIFF
--- a/frontend/src/components/about/Goal.vue
+++ b/frontend/src/components/about/Goal.vue
@@ -1,0 +1,46 @@
+<template>
+    <div id="mission-header">Our Goals</div>
+        <div id="blurb">It is envisioned that the platform will<br>
+           provide data that will empower users<br>
+            with valuable insights, foster inclusivity,<br>
+             and inspire positive change within the STEM community.
+        </div>
+    <div id="swiggle"><img src="/swiggly_line_ACF0FF.svg" /></div>  
+  </template>
+  
+  <style>
+  #outer {
+    display: flex;
+  }
+
+  #mission-header {
+    color: #ACF0FF;
+    text-align: center;
+    font-family: Google Sans;
+    font-size: 1.875rem;
+    font-style: normal;
+    font-weight: 500;
+    line-height: 3.75rem; /* 200% */
+    margin-top: 20.5rem;
+    margin-bottom: 2.38rem;
+  }
+  
+  #blurb {
+    margin-bottom: 0;
+    font-family: 'Noto Sans';
+    color: #FFF;
+    text-align: center;
+    font-size: 3.75rem;
+    font-style: normal;
+    font-weight: 400;
+    line-height: normal;
+  }
+  
+  #swiggle {
+    margin: 4rem 0;
+    margin-left: 31.53rem;
+    margin-bottom: 7.48rem;
+  }
+  
+  
+  </style>

--- a/frontend/src/components/about/Vision.vue
+++ b/frontend/src/components/about/Vision.vue
@@ -8,8 +8,6 @@
       <div id="swiggle-vision-card"><img src="/swiggly_line_ACF0FF.svg" /></div>  
       </div>
   </div>
-  <div id="building-vision-header">Building the Vision</div>
-  <div id="swiggle"><img src="/swiggly_line_ACF0FF.svg" /></div>
 </template>
 
 <style scoped>

--- a/frontend/src/home/Splash.vue
+++ b/frontend/src/home/Splash.vue
@@ -1,3 +1,13 @@
+<script setup lang="ts">
+import { useRouter } from 'vue-router';
+const router = useRouter();
+
+function goToData() {
+  router.push({ name: 'data' })
+}
+
+</script>
+
 <template>
   <h1>
     Breaking Boundaries<br />
@@ -8,7 +18,7 @@
     Amplifying the stories and impact of Black women in STEM<br />
     through data, insights, and advocacy
   </p>
-  <button>Visit the Data Dashboard</button>
+  <button @click="goToData">Visit the Data Dashboard</button>
   <div id="splash-graphics">
     <img src="/splash.png" alt="" id="splash-image" />
     <img src="/swiggly_red_FF6454.svg" alt="" id="swiggly-red" />

--- a/frontend/src/home/Stat.vue
+++ b/frontend/src/home/Stat.vue
@@ -4,13 +4,14 @@
     <div id="percent">
       <span class="big-percent">2.9</span>
       <span class="big-percent">%</span>
-      <p id="blurb">Explore the commitment to increasing<br />
+      <div id="percent-blurb">In 2021, only 2.9% of the STEM<br> workforce in the
+        United States<br> are Black women.</div>
+      <div id="squiggle"><img src="/swiggly_line_ACF0FF.svg" /></div>
+      <p id="footnote">
+        Explore the commitment to increasing<br />
         representation, improving access to<br />
         resources and strengthening<br />
         community partnerships.</p>
-      <div id="swiggle"><img src="/swiggly_line_ACF0FF.svg" /></div>
-      <p id="footnote">In 2021, only 2.9% of the STEM workforce in the<br />
-        US are Black women.</p>
     </div>
     <div id="bullet-points">
       <div class="bullet-point">
@@ -40,15 +41,25 @@
 </template>
 
 <style>
+@import url('https://fonts.googleapis.com/css2?family=Noto+Sans+Mono&family=Open+Sans&display=swap');
+
 #outer {
   display: flex;
 }
 
-#blurb {
+#percent-blurb {
   margin-bottom: 0;
+  font-family: 'Noto Sans Mono';
+  color: #FFF;
+  text-align: center;
+  font-size: 1.875rem;
+  font-style: normal;
+  font-weight: 500;
+  line-height: normal;
+  text-align: left;
 }
 
-#swiggle {
+#squiggle {
   margin: 4rem 0;
 }
 

--- a/frontend/src/views/AboutView.vue
+++ b/frontend/src/views/AboutView.vue
@@ -2,6 +2,7 @@
 import Splash from '@/components/about/Splash.vue'
 import Mission from '@/components/about/Mission.vue'
 import Vision from '@/components/about/Vision.vue'
+import Goal from '@/components/about/Goal.vue'
 import TeamStories from '@/about/TeamStories.vue'
 </script>
 
@@ -12,11 +13,19 @@ import TeamStories from '@/about/TeamStories.vue'
   <div class="view gradient">
     <Mission></Mission>
   </div>
-  <!-- TODO: Debug gradient -->
   <div class="view">
     <Vision></Vision>
   </div>
   <div class="view gradient">
+    <Goal></Goal>
+  </div>
+  <div class="view">
     <TeamStories></TeamStories>
   </div>
 </template>
+
+<style scoped>
+div.gradient {
+  background: linear-gradient(180deg, rgba(34, 38, 43, 0.00) 0%, #181818 100%);
+}
+</style>

--- a/frontend/src/views/HomeView.vue
+++ b/frontend/src/views/HomeView.vue
@@ -12,13 +12,10 @@ import MoreToExplore from '@/home/MoreToExplore.vue'
     <Splash></Splash>
   </div>
   <div class="view gradient">
-    <ExploreData></ExploreData>
+    <Stat></Stat>
   </div>
   <div class="view">
     <Stories></Stories>
-  </div>
-  <div class="view gradient">
-    <Stat></Stat>
   </div>
   <div class="view">
     <MoreToExplore></MoreToExplore>


### PR DESCRIPTION
Demo: 
[Screen recording 2023-08-29 3.33.59 PM.webm](https://github.com/Spelman-College/spelman-dashboard/assets/13266735/15dbcf7b-351b-42ff-9b83-9976d3a9296a)

Shifts percentage splash higher on landing page; connects data dashboard button to data view; adds additional component to about page