### PR TITLE
move filter click-away detection behind filters

### DIFF
--- a/frontend/src/components/ClickawayDetection.vue
+++ b/frontend/src/components/ClickawayDetection.vue
@@ -9,6 +9,6 @@
   left: 0;
   width: 100vw;
   height: 100vh;
-  z-index: 100;
+  z-index: 0;
 }
 </style>

--- a/frontend/src/components/FilterChip.vue
+++ b/frontend/src/components/FilterChip.vue
@@ -102,6 +102,7 @@ function searchFilter(op: string) {
 <style scoped>
 .filter-chip-dropdown-container {
   position: relative;
+  z-index: 1;
 }
 
 .filter-chip {


### PR DESCRIPTION
- we'll likely want to close the current filter and open the other if a different filter is selected when a single filter is opened. 
- I believe we'll also want to remove the Apply button at some point and do real-time filtering on select. 