### PR TITLE
Fix homepage link colors and carousel arrow formatting

### DIFF
--- a/frontend/src/components/ExploreCard.vue
+++ b/frontend/src/components/ExploreCard.vue
@@ -14,9 +14,9 @@ const props = defineProps({
     <div class="body">
       <slot name="text"></slot>
     </div>
-    <div class="link">
+    <div class="link" id="link">
       <a>
-        <slot name="link"></slot> &rarr;
+        <slot name="link"></slot><span class="material-symbols-outlined">arrow_right_alt</span> 
       </a>
     </div>
   </div>
@@ -59,5 +59,18 @@ const props = defineProps({
   font-family: 'Roboto';
   font-size: 1.3125rem;
   width: 22.5625rem;
+}
+
+#link a {
+  color: #4fdfff;
+}
+
+#link .material-symbols-outlined {
+  width: 1.5rem;
+  height: 1.5rem;
+  flex-shrink: 0;
+  color: #4fdfff;
+  margin-left: 0.81rem;
+  vertical-align:middle;
 }
 </style>

--- a/frontend/src/home/Stat.vue
+++ b/frontend/src/home/Stat.vue
@@ -37,11 +37,17 @@
       </div>
     </div>
   </div>
-  <a href="">Learn more &rarr;</a>
+  <div id="link">
+    <a href="">Learn more <span class="material-symbols-outlined">arrow_right_alt</span></a>
+  </div>
 </template>
 
 <style>
 @import url('https://fonts.googleapis.com/css2?family=Noto+Sans+Mono&family=Open+Sans&display=swap');
+
+#link a {
+  color: #4fdfff;
+}
 
 #outer {
   display: flex;
@@ -117,6 +123,15 @@
   height: 4rem;
   font-size: 3rem;
   color: #ffffff;
+}
+
+#link .material-symbols-outlined {
+  width: 1.5rem;
+  height: 1.5rem;
+  flex-shrink: 0;
+  color: #4fdfff;
+  margin-left: 0.81rem;
+  vertical-align:middle;
 }
 
 #source {

--- a/frontend/src/home/Stories.vue
+++ b/frontend/src/home/Stories.vue
@@ -42,8 +42,8 @@ const page = ref(0)
   </p>
 
   <div class="carousel-nav">
-    <button class="carousel-nav-buttons" @click="prevPage">&larr;</button> <button class="carousel-nav-buttons"
-      @click="nextPage">&rarr;</button>
+    <button class="carousel-nav-buttons" @click="prevPage"><div id="carousel-arrows"><span class="material-symbols-outlined">arrow_left_alt</span></div></button> <button class="carousel-nav-buttons"
+      @click="nextPage"><div id="carousel-arrows"><span class="material-symbols-outlined">arrow_right_alt</span></div></button>
   </div>
   <div>
     <Carousel :value="rows" :numVisible="3" :numScroll="3" :show-indicators="false" :circular="true"
@@ -91,13 +91,11 @@ a {
   line-height: 1.875rem; /* 142.857% */
 }
 
-.material-symbols-outlined {
-  width: 1.5rem;
-  height: 1.5rem;
-  flex-shrink: 0;
-  color: #313B49;
-  margin-left: 0.81rem;
-  vertical-align:middle;
+/* TODO: Center arrows and change to material-symbols-rounded */
+#carousel-arrows .material-symbols-outlined {
+  margin-left: 0rem;
+  width: 0.975rem;
+  ;
 }
 
 </style>


### PR DESCRIPTION
'Learn more' button (& friends) are now the proper color and font:
![image](https://github.com/Spelman-College/spelman-dashboard/assets/13266735/56607c5b-1bc8-4aae-836f-543a6fff374e)
