### PR TITLE
Standardized the button icons to material-symbols-rounded

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -4,7 +4,7 @@
 <head>
   <meta charset="UTF-8">
   <link rel="icon" href="/favicon.ico">
-  <link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined" rel="stylesheet" />
+  <link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Rounded" rel="stylesheet" />
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link

--- a/frontend/src/about/TeamStories.vue
+++ b/frontend/src/about/TeamStories.vue
@@ -28,8 +28,8 @@ function goToBiosView() {
   </p>
 
   <div class="carousel-nav">
-    <button class="carousel-nav-buttons" @click="prevPage">&larr;</button> <button class="carousel-nav-buttons"
-      @click="nextPage">&rarr;</button>
+    <button class="carousel-nav-buttons" @click="prevPage"><span class="material-symbols-rounded">arrow_left_alt</span></button> <button class="carousel-nav-buttons"
+      @click="nextPage"><span class="material-symbols-rounded">arrow_right_alt</span></button>
   </div>
   <div>
     <Carousel :value="bios" :numVisible="4" :numScroll="1" :show-indicators="false" :circular="true"
@@ -38,7 +38,7 @@ function goToBiosView() {
         <TeamStoryCard :img-src="slotProps.data.imgSrc" width="19.7">
           <template #name>{{ slotProps.data.name }}</template>
           <template #story>{{ slotProps.data.story }}</template>
-          <template #linkText><router-link :to="{path: '/bios/' + slotProps.index}">Read her story<span class="material-symbols-outlined">arrow_right_alt</span></router-link></template>
+          <template #linkText><router-link :to="{path: '/bios/' + slotProps.index}">Read her story<span class="material-symbols-rounded">arrow_right_alt</span></router-link></template>
         </TeamStoryCard>
       </template>
     </Carousel>
@@ -62,11 +62,11 @@ function goToBiosView() {
   margin-bottom: 4em;
 }
 
-.carousel-nav button {
-  text-align: center;
-  width: 4em;
-  height: 4em;
-  margin-left: 2em;
+.carousel-nav button .material-symbols-rounded{
+  margin-left: 0rem;
+  width: 0.975rem;
+  display:flex;
+  justify-content:center;
 }
 
 .hidden {
@@ -82,7 +82,7 @@ a {
   line-height: 1.875rem; /* 142.857% */
 }
 
-.material-symbols-outlined {
+.material-symbols-rounded {
   width: 1.5rem;
   height: 1.5rem;
   flex-shrink: 0;

--- a/frontend/src/components/ExploreCard.vue
+++ b/frontend/src/components/ExploreCard.vue
@@ -16,7 +16,7 @@ const props = defineProps({
     </div>
     <div class="link" id="link">
       <a>
-        <slot name="link"></slot><span class="material-symbols-outlined">arrow_right_alt</span> 
+        <slot name="link"></slot><span class="material-symbols-rounded">arrow_right_alt</span> 
       </a>
     </div>
   </div>
@@ -65,7 +65,7 @@ const props = defineProps({
   color: #4fdfff;
 }
 
-#link .material-symbols-outlined {
+#link .material-symbols-rounded {
   width: 1.5rem;
   height: 1.5rem;
   flex-shrink: 0;

--- a/frontend/src/components/resources/Reads.vue
+++ b/frontend/src/components/resources/Reads.vue
@@ -35,8 +35,8 @@ const books = [
   <p>Check out these amazing stories of resilience, brilliance, and groundbreaking achievements! We're celebrating the
     unsung heroes of STEM - Science, Technology, Engineering, and Mathematics.</p>
   <div class="carousel-nav">
-    <button class="carousel-nav-buttons" @click="prevPage">&larr;</button> <button class="carousel-nav-buttons"
-      @click="nextPage">&rarr;</button>
+    <button class="carousel-nav-buttons" @click="prevPage"><span class="material-symbols-rounded">arrow_left_alt</span></button> <button class="carousel-nav-buttons"
+      @click="nextPage"><span class="material-symbols-rounded">arrow_right_alt</span></button>
   </div>
   <div>
     <Carousel :value="books" :numVisible="5" :numScroll="5" :show-indicators="false" :circular="true"

--- a/frontend/src/home/Stat.vue
+++ b/frontend/src/home/Stat.vue
@@ -38,7 +38,7 @@
     </div>
   </div>
   <div id="link">
-    <a href="">Learn more <span class="material-symbols-outlined">arrow_right_alt</span></a>
+    <a href="">Learn more <span class="material-symbols-rounded">arrow_right_alt</span></a>
   </div>
 </template>
 
@@ -125,7 +125,7 @@
   color: #ffffff;
 }
 
-#link .material-symbols-outlined {
+#link .material-symbols-rounded {
   width: 1.5rem;
   height: 1.5rem;
   flex-shrink: 0;

--- a/frontend/src/home/Stories.vue
+++ b/frontend/src/home/Stories.vue
@@ -42,8 +42,8 @@ const page = ref(0)
   </p>
 
   <div class="carousel-nav">
-    <button class="carousel-nav-buttons" @click="prevPage"><div id="carousel-arrows"><span class="material-symbols-outlined">arrow_left_alt</span></div></button> <button class="carousel-nav-buttons"
-      @click="nextPage"><div id="carousel-arrows"><span class="material-symbols-outlined">arrow_right_alt</span></div></button>
+    <button class="carousel-nav-buttons" @click="prevPage"><div id="carousel-arrows"><span class="material-symbols-rounded">arrow_left_alt</span></div></button> <button class="carousel-nav-buttons"
+      @click="nextPage"><div id="carousel-arrows"><span class="material-symbols-rounded">arrow_right_alt</span></div></button>
   </div>
   <div>
     <Carousel :value="rows" :numVisible="3" :numScroll="3" :show-indicators="false" :circular="true"
@@ -53,7 +53,7 @@ const page = ref(0)
           <template #name>{{ slotProps.data.name }}</template>
           <template #profession>{{ slotProps.data.profession }}</template>
           <template #story>{{ slotProps.data.how_did_you_choose_this_path }}</template>
-          <template #linkText><router-link :to="{path: '/stories/' + slotProps.index}">Read her story<span class="material-symbols-outlined">arrow_right_alt</span></router-link></template>
+          <template #linkText><router-link :to="{path: '/stories/' + slotProps.index}">Read her story<span class="material-symbols-rounded">arrow_right_alt</span></router-link></template>
         </StoryCard>
       </template>
     </Carousel>
@@ -91,11 +91,11 @@ a {
   line-height: 1.875rem; /* 142.857% */
 }
 
-/* TODO: Center arrows and change to material-symbols-rounded */
-#carousel-arrows .material-symbols-outlined {
+#carousel-arrows .material-symbols-rounded {
   margin-left: 0rem;
   width: 0.975rem;
-  ;
+  display:flex;
+  justify-content:center;
 }
 
 </style>

--- a/frontend/src/views/BiosView.vue
+++ b/frontend/src/views/BiosView.vue
@@ -14,7 +14,7 @@ import bios from '@/about/bios.ts'
     <TeamStoryCard v-for="(story, index) in bios" :v-key="story.name" :imgSrc="story.imgSrc" :alt="story.name" width="20">
       <template #name>{{ story.name }}</template>
       <template #story>{{ story.story }}</template>
-      <template #linkText><router-link :to="{path: '/bios/' + index}">Read her story<span class="material-symbols-outlined">arrow_right_alt</span></router-link></template>
+      <template #linkText><router-link :to="{path: '/bios/' + index}">Read her story<span class="material-symbols-rounded">arrow_right_alt</span></router-link></template>
     </TeamStoryCard>
   </div>
 </template>
@@ -50,7 +50,7 @@ a {
   white-space: nowrap;
 }
 
-.material-symbols-outlined {
+.material-symbols-rounded {
   width: 1.5rem;
   height: 1.5rem;
   flex-shrink: 0;

--- a/frontend/src/views/ContactView.vue
+++ b/frontend/src/views/ContactView.vue
@@ -10,7 +10,7 @@
         Email us at <div class="email">email@spelman.edu</div>
         <br><br>
         <span class="contact-text">
-          <span class="material-symbols-outlined">pin_drop</span>
+          <span class="material-symbols-rounded">pin_drop</span>
           <br>
           Lorem ipsum dolor sit
           amet, consectuer
@@ -85,5 +85,8 @@
   font-style: normal;
   font-weight: 400;
   line-height: 1.25rem; /* 125% */
+}
+.material-symbols-rounded{
+  margin-left:0
 }
 </style>

--- a/frontend/src/views/ContactView.vue
+++ b/frontend/src/views/ContactView.vue
@@ -86,7 +86,7 @@
   font-weight: 400;
   line-height: 1.25rem; /* 125% */
 }
-.material-symbols-rounded{
+.contact-text .material-symbols-rounded{
   margin-left:0
 }
 </style>

--- a/frontend/src/views/IndividualBioView.vue
+++ b/frontend/src/views/IndividualBioView.vue
@@ -21,7 +21,7 @@ watch(route, () => {
 
 <template>
   <div class="view">
-    <router-link id="back-button" class="material-icons" :to="{ name: 'bios' }">chevron_left</router-link>
+    <router-link id="back-button" class="material-symbols-rounded" :to="{ name: 'bios' }">chevron_left</router-link>
     <div class="side-by-side">
       <div>
         <img class="profile-img" :src="thisStory.imgSrc" />
@@ -39,10 +39,10 @@ watch(route, () => {
 </template>
 
 <style scoped>
-#back-button {
+ #back-button {
   font-size: 2.5rem;
   color: #ffffff;
-  margin-bottom: 1rem;
+  margin-bottom: 3rem;
 }
 
 .side-by-side {

--- a/frontend/src/views/IndividualStoryView.vue
+++ b/frontend/src/views/IndividualStoryView.vue
@@ -31,7 +31,7 @@ watch(route, () => {
 
 <template>
   <div class="view">
-    <router-link id="back-button" class="material-icons" :to="{ name: 'stories' }">chevron_left</router-link>
+    <router-link id="back-button" class="material-symbols-rounded" :to="{ name: 'stories' }">chevron_left</router-link>
     <div class="side-by-side">
       <div>
         <img class="profile-img" :src="thisStory.hosted_image_link" />
@@ -66,7 +66,7 @@ watch(route, () => {
 #back-button {
   font-size: 2.5rem;
   color: #ffffff;
-  margin-bottom: 1rem;
+  margin-bottom: 3rem;
 }
 
 .side-by-side {

--- a/frontend/src/views/StoriesView.vue
+++ b/frontend/src/views/StoriesView.vue
@@ -31,7 +31,7 @@ onMounted(() => {
       <template #name>{{ story.name }}</template>
       <template #profession>{{ story.profession }}</template>
       <template #story>{{ story.how_did_you_choose_this_path }}</template>
-      <template #linkText><router-link :to="{path: '/stories/' + index}">Read her story<span class="material-symbols-outlined">arrow_right_alt</span></router-link></template>
+      <template #linkText><router-link :to="{path: '/stories/' + index}">Read her story<span class="material-symbols-rounded">arrow_right_alt</span></router-link></template>
     </StoryCard>
   </div>
 </template>
@@ -67,7 +67,7 @@ a {
   white-space: nowrap;
 }
 
-.material-symbols-outlined {
+.material-symbols-rounded {
   width: 1.5rem;
   height: 1.5rem;
   flex-shrink: 0;

--- a/frontend/src/views/reads/IndividualReadsView.vue
+++ b/frontend/src/views/reads/IndividualReadsView.vue
@@ -78,7 +78,7 @@ let thisBook = books[route.params.id];
 
 <template>
   <div class="view">
-    <router-link id="back-button" class="material-icons" :to="{ name: 'resources' }">chevron_left</router-link>
+    <router-link id="back-button" class="material-symbols-rounded" :to="{ name: 'resources' }">chevron_left</router-link>
     <div class="side-by-side">
       <div>
         <img class="profile-img" :src="thisBook.imgSrc" />
@@ -100,7 +100,7 @@ let thisBook = books[route.params.id];
 #back-button {
   font-size: 2.5rem;
   color: #ffffff;
-  margin-bottom: 1rem;
+  margin-bottom: 3rem;
 }
 
 .side-by-side {


### PR DESCRIPTION
Before: Stories.vue top navigation buttons
<img width="190" alt="Home_before" src="https://github.com/Spelman-College/spelman-dashboard/assets/92114989/49cf6b8a-2852-4b00-bea8-5b0e94eed40a">

After: Stories.vue top navigation buttons
<img width="190" alt="Home_after" src="https://github.com/Spelman-College/spelman-dashboard/assets/92114989/96bf98b5-bb2f-4410-812f-bab8ac508df4">


Before: TeamStories.vue bottom navigation buttons
<img width="235" alt="About_before" src="https://github.com/Spelman-College/spelman-dashboard/assets/92114989/aca958dc-3842-4fe2-86a8-149363ef4d4c">

After: TeamStores.vue bottom navigation buttons
<img width="235" alt="About_before" src="https://github.com/Spelman-College/spelman-dashboard/assets/92114989/004e4dc3-8d7d-43aa-9f4c-8853080afee9">

Notes:

- updated buttons sitewide to material-symbols-rounded
- centered arrows in buttons if necessary