### PR TITLE
Small updates to dashboard UI click reactivity

### DIFF
--- a/frontend/src/components/dashboard/DatasetSelector.vue
+++ b/frontend/src/components/dashboard/DatasetSelector.vue
@@ -63,7 +63,7 @@ watch(selected, () => {
 
 function handleClick(name: String | null) {
     if (name === null)
-        dropdownShowing.value = dropdownShowing.value === '' ? dropdownShowingId : '';
+        dropdownShowing.value = dropdownShowing.value !== 'datasetDropdown' ? dropdownShowingId : '';
     else {
         const idx = options.findIndex(option => option.name === name)
         selectedIndex.value = idx

--- a/frontend/src/components/dashboard/FilterChip.vue
+++ b/frontend/src/components/dashboard/FilterChip.vue
@@ -161,7 +161,7 @@ function searchFilter(op: string) {
 
 .chip-dropdown {
     position: absolute;
-    top: 2.5rem;
+    top: 100%;
     left: 0.5rem;
     width: 22.5rem;
     background-color: #ffffff;


### PR DESCRIPTION
DONE in this PR:

- Pin filter chip dropdown to the bottom of each filter chip so they don't overlap each other
- Opens the dataset dropdown menu in one click instead of two when you click from an open filter chip dropdown. For example, if you decide to change datasets in the view below without closing the Gender dropdown menu first.

Before: filter chip dropdown
<img width="493" alt="Screenshot 2023-09-06 at 9 22 36 PM" src="https://github.com/Spelman-College/spelman-dashboard/assets/92114989/0876ad7e-7324-44a7-94c4-67136b630585">


After: filter chip dropdown
<img width="493" alt="Screenshot 2023-09-06 at 9 26 11 PM" src="https://github.com/Spelman-College/spelman-dashboard/assets/92114989/2da29ea2-5c0c-4200-b09f-b003bd4335ef">