### PR TITLE
Add working directory to prettier format config

### DIFF
--- a/.github/workflows/prettier-format.yml
+++ b/.github/workflows/prettier-format.yml
@@ -19,8 +19,10 @@ jobs:
           node-version: lts/*
       - name: Install packages
         run: npm ci
+        working-directory: ./frontend
       - name: Format files
         run: npm run format
+        working-directory: ./frontend
       - name: Commit changes
         uses: stefanzweifel/git-auto-commit-action@v4
         with:


### PR DESCRIPTION
Fixes an issue where the run failed to install npm packages since it ran in the wrong directory