### PR TITLE
UI updates to Demo dashboard ploting

### DIFF
--- a/frontend/src/components/dashboard/data/Demo.vue
+++ b/frontend/src/components/dashboard/data/Demo.vue
@@ -50,6 +50,8 @@ const compare = ref('gender')
 const tableItems = ref([])
 const colorDomain = ref([])
 
+const plotType = ref('bar')
+
 async function download(items: Array<Map>) {
   loading_download.value = true
 
@@ -151,6 +153,9 @@ const updateFilter = (filterId: string, activeFilters: Array<string>) => {
 const changeCompare = (val: string) => {
   compare.value = val
 }
+const updatePlotType = (newPlotType: string) => {
+  plotType.value = newPlotType
+}
 </script>
 
 <template>
@@ -183,9 +188,26 @@ const changeCompare = (val: string) => {
     <div class="data-type-and-download-container">
       <div class="plot-text choose-data-type">
         <div class="data-type-text">Data type</div>
-        <div class="plot-button choose-bar"><span class="material-icons">bar_chart</span></div>
-        <div class="plot-button choose-line"><span class="material-icons">timeline</span></div>
-        <div class="plot-button choose-pie"><span class="material-icons">pie_chart</span></div>
+        <div
+          @click="updatePlotType('bar')"
+          class="plot-button choose-bar"
+          :class="{ active: plotType === 'bar' }"
+        >
+          <span class="material-icons">bar_chart</span>
+        </div>
+        <div
+          @click="updatePlotType('line')"
+          class="plot-button choose-line"
+          :class="{ active: plotType === 'line' }"
+        >
+          <span class="material-icons">timeline</span>
+        </div>
+        <div
+          class="plot-button unavailable choose-pie"
+          :class="{ active: plotType === 'pie' }"
+        >
+          <span class="material-icons">pie_chart_outline</span>
+        </div>
       </div>
       <div class="csv-download-container">
         <div class="plot-text">Download data</div>
@@ -200,40 +222,14 @@ const changeCompare = (val: string) => {
         </div>
       </div>
     </div>
-    <!-- <div>{{ datasetMeta.name }}</div> -->
+<!-- <div>{{ datasetMeta.name }}</div> -->
     <div v-if="true" class="plot">
       <PlotFigure
         v-if="tableItems.length > 0"
-        :options="{
-          x: {
-            axis: null,
-            tickFormat: '',
-            type: 'band'
-          },
-          y: {
-            tickFormat: 's',
-            grid: true
-          },
-          fx: {
-            label: null
-          },
-          color: {
-            domain: colorDomain,
-            legend: true
-          },
-          marks: [
-            Plot.barY(tableItems, {
-              x: 'key',
-              y: 'value',
-              fx: 'date',
-              fill: 'key',
-              sort: {
-                x: null
-              }
-            }),
-            Plot.ruleY([0])
-          ]
-        }"
+        :plotType="plotType"
+        :datasetMetaName="datasetMeta.name"
+        :tableItems="tableItems"
+        :colorDomain="colorDomain"
       >
       </PlotFigure>
     </div>
@@ -250,6 +246,12 @@ const changeCompare = (val: string) => {
   margin: 1rem 0;
 }
 
+.filter-text {
+  color: #ffffff;
+  font-family: 'Noto Sans Mono';
+  font-size: 0.875rem;
+  font-weight: 700;
+}
 .data-dashboard-plot {
   color: black;
   border-radius: 8px;
@@ -280,7 +282,7 @@ const changeCompare = (val: string) => {
 }
 .csv {
   color: #1a73e8;
-  font-family: Google Sans Mono;
+  font-family: Noto Sans Mono;
   font-size: 12px;
 }
 .csv-download-container {
@@ -304,7 +306,14 @@ const changeCompare = (val: string) => {
   gap: 8px;
   border-radius: 4px;
   border: 1px solid #bdc1c6;
+}
+
+.plot-button.active {
   background: #ececec;
+}
+.plot-button.unavailable{
+  color: #bdc1c6;
+  border: 1px solid #ececec;
 }
 .plot-text {
   font-family: 'Noto Sans Mono';

--- a/frontend/src/components/dashboard/data/PlotFigure.vue
+++ b/frontend/src/components/dashboard/data/PlotFigure.vue
@@ -1,11 +1,92 @@
 <script setup lang="ts">
 import * as Plot from '@observablehq/plot'
+import {ref, watch, toRefs} from 'vue'
 
 const props = defineProps({
-  options: Object
+  tableItems: Object,
+  colorDomain: Array<string>,
+  plotType: String,
+  datasetMetaName: String
 })
+
+const { tableItems, colorDomain, plotType, datasetMetaName } = toRefs(props);
+const plotWidth = ref(1000)
+const data = props.tableItems;
+// let plotType = ref(props.plotType);
+function getPlotOptions(plotType, data) {
+  const oPlotTypeOptions = {
+    bar:{
+        x: {
+          axis: null,
+          tickFormat: '',
+          type: 'band',
+          scale: "point",
+
+        },
+        y: {
+          tickFormat: 's',
+          grid: true
+        },
+        fx: {
+          label: null
+        },
+        color: {
+          domain: props.colorDomain,
+          legend: true
+        },
+        marks: [
+          Plot.barY(data, {
+            x: 'key',
+            y: 'value',
+            fx: 'date',
+            fill: 'key',
+            sort: {
+              x: null
+            }
+          }),
+          Plot.ruleY([0])
+        ],
+      },
+    // line: {
+    //     x: {
+    //       label: null,
+    //       scale: "point",
+    //     },
+    //     y: {
+    //       grid: true,
+    //       label:null,
+    //     },
+    //     facet: {
+    //       data,
+    //       groupby: "key",
+    //     },
+    //     marks: [
+    //       Plot.ruleY([0]),
+    //       Plot.line(data, {
+    //         x: "date",
+    //         y: "value",
+    //         stroke: "key",
+    //         curve: "linear",
+    //       }),
+    //     ],
+    //   },
+  };
+  return oPlotTypeOptions[plotType] || oPlotTypeOptions.bar;
+}
+
+const oDefaultConfig = getPlotOptions(plotType, data);
+const plotHTML = ref(Plot.plot(oDefaultConfig).outerHTML);
+
+ // get plot options for the current plot type
+ watch(plotType, (newPlotType) => {
+      const oConfig = getPlotOptions(newPlotType, data);
+      plotHTML.value = Plot.plot(oConfig).outerHTML;
+
+    });
+
 </script>
 
 <template>
-  <div v-html="Plot.plot(props.options).outerHTML" />
+  <div v-html="plotHTML" />
 </template>
+

--- a/frontend/src/components/dashboard/data/PlotFigure.vue
+++ b/frontend/src/components/dashboard/data/PlotFigure.vue
@@ -75,12 +75,12 @@ function getPlotOptions(plotType, data) {
 }
 
 const oDefaultConfig = getPlotOptions(plotType, data);
-const plotHTML = ref(Plot.plot(oDefaultConfig).outerHTML);
+const plotHTML = ref(Plot.plot({...oDefaultConfig, width: 1000}).outerHTML);
 
  // get plot options for the current plot type
  watch(plotType, (newPlotType) => {
       const oConfig = getPlotOptions(newPlotType, data);
-      plotHTML.value = Plot.plot(oConfig).outerHTML;
+      plotHTML.value = Plot.plot({...oConfig, width: 1000}).outerHTML;
 
     });
 


### PR DESCRIPTION
TO DO in this PR:
- fix display of line chart
<img width="1121" alt="Screen Shot 2023-09-11 at 7 54 22 PM" src="https://github.com/Spelman-College/spelman-dashboard/assets/92114989/f34ae2f5-6b11-40ee-a6f6-6a9145706960">
- update plot colors, text size, + type
- update legend placement and size
- look into update speed - switching between views (gender, age, etc.) is now much slower

DONE in this PR:
- Moved plotting configuration options to PlotFigure.vue
- spread plot over x axis and fixed width at 1000px for MVP
- activated toggle between chart types

Before: bar
<img width="1121" alt="Screen Shot 2023-09-11 at 7 56 33 PM" src="https://github.com/Spelman-College/spelman-dashboard/assets/92114989/5aad1b8b-d97e-4939-b132-848dd13e0879">
 chart

After: bar chart
<img width="1121" alt="Screen Shot 2023-09-11 at 7 54 16 PM" src="https://github.com/Spelman-College/spelman-dashboard/assets/92114989/634f5a2f-d4a0-4772-97a6-ed79855acee4">
