### PR TITLE
Plot formatting only

### DIFF
--- a/frontend/src/components/dashboard/DataDashboard.vue
+++ b/frontend/src/components/dashboard/DataDashboard.vue
@@ -73,7 +73,7 @@ const props = defineProps(['dataset', 'view'])
 }
 :deep(.csv) {
   color: #1a73e8;
-  font-family: Google Sans Mono;
+  font-family: Noto Sans Mono;
   font-size: 12px;
 }
 :deep(.csv-download-container) {
@@ -99,6 +99,12 @@ const props = defineProps(['dataset', 'view'])
   border: 1px solid #bdc1c6;
   background: #ececec;
 }
+:deep(.plot-button.unavailable) {
+  background: white;
+  color: #bdc1c6;
+  border: 1px solid #ececec;
+}
+
 :deep(.plot-text) {
   font-family: 'Noto Sans Mono';
   font-size: 12px;

--- a/frontend/src/components/dashboard/PlotHeader.vue
+++ b/frontend/src/components/dashboard/PlotHeader.vue
@@ -10,9 +10,9 @@ const props = defineProps(['downloadFunc', 'loading', 'title'])
   <div class="data-type-and-download-container">
     <div class="plot-text choose-data-type">
       <div class="data-type-text">Data type</div>
-      <div class="plot-button choose-bar"><span class="material-icons">bar_chart</span></div>
-      <div class="plot-button choose-line"><span class="material-icons">timeline</span></div>
-      <div class="plot-button choose-pie"><span class="material-icons">pie_chart</span></div>
+      <div class="plot-button"><span class="material-icons">bar_chart</span></div>
+      <div class="plot-button unavailable"><span class="material-icons">timeline</span></div>
+      <div class="plot-button unavailable"><span class="material-icons">pie_chart_outline</span></div>
     </div>
     <div class="csv-download-container">
       <div class="plot-text">Download data</div>

--- a/frontend/src/components/dashboard/data/Demo.vue
+++ b/frontend/src/components/dashboard/data/Demo.vue
@@ -50,6 +50,8 @@ const filters = dashboardFilters
 const compare = ref('gender')
 const tableItems = ref([])
 const colorDomain = ref([])
+// Can add a custom color palette here, in the order they'll appear
+// const categorialColors = ['#96bdff',"#e0ebff",'#B6D1FF', '#2d394c', '#7897CC', '#3C4C66', '#1E2633', '#A1C4FF', '7897CC']
 
 async function download() {
   loading_download.value = true
@@ -176,8 +178,6 @@ const changeCompare = (val: string) => {
       :loading="loading_download"
       :title="datasetMeta.name"
     />
-
-    <!-- <div>{{  }}</div> -->
     <div v-if="true" class="plot">
       <PlotFigure
         v-if="tableItems.length > 0"
@@ -196,7 +196,9 @@ const changeCompare = (val: string) => {
           },
           color: {
             domain: colorDomain,
-            legend: true
+          // Can update categoricalColors variable with a custom color range (ex. range: categoricalColors)
+          // or use a scheme, e.g.: scheme:'Reds'            
+            scheme:'Blues',
           },
           marks: [
             Plot.barY(tableItems, {
@@ -212,7 +214,7 @@ const changeCompare = (val: string) => {
           ]
         }"
       >
-      </PlotFigure>
-    </div>
-  </div>
+            </PlotFigure>
+       </div>
+     </div>
 </template>

--- a/frontend/src/components/dashboard/data/PlotFigure.vue
+++ b/frontend/src/components/dashboard/data/PlotFigure.vue
@@ -7,5 +7,5 @@ const props = defineProps({
 </script>
 
 <template>
-  <div v-html="Plot.plot(props.options).outerHTML" />
+  <div v-html="Plot.plot({...props.options, width:1000}).outerHTML" />
 </template>

--- a/frontend/src/components/dashboard/data/PlotFigure.vue
+++ b/frontend/src/components/dashboard/data/PlotFigure.vue
@@ -7,5 +7,5 @@ const props = defineProps({
 </script>
 
 <template>
-  <div v-html="Plot.plot({...props.options, width:1000}).outerHTML" />
-</template>
+  <div v-html="Plot.plot({...props.options, width:1200}).outerHTML" />
+  </template>


### PR DESCRIPTION
DONE in this PR:

- spread plot along x-axis
- temporarily update colorways and added ability to set a custom array of colors
    - TODO: ask UXD for a palette of 10-20 colors
- marked other plotting options (i.e. line and pie) as unavailable for now

Before: plot width + default Plot colors
<img width="1228" alt="Screen Shot 2023-09-12 at 2 58 36 PM" src="https://github.com/Spelman-College/spelman-dashboard/assets/92114989/163caf02-6615-47fb-afb5-ec65e6abf969">

After: plot width + (temp) blue colorway
<img width="1228" alt="Screen Shot 2023-09-12 at 2 58 27 PM" src="https://github.com/Spelman-College/spelman-dashboard/assets/92114989/55fcce2a-ff5a-4367-ab84-3b79046d80c9">

Before: available chart options
<img width="287" alt="Screen Shot 2023-09-12 at 2 54 05 PM" src="https://github.com/Spelman-College/spelman-dashboard/assets/92114989/b2d76f90-ba53-4854-b0c0-53bcd63fa1ab">

After: available chart options
<img width="287" alt="Screen Shot 2023-09-12 at 2 54 14 PM" src="https://github.com/Spelman-College/spelman-dashboard/assets/92114989/9c48c4c9-1176-46bf-b048-d51c4169412b">
