### PR TITLE
formatting fix for viewing site on large screens

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -24,7 +24,9 @@ div#container {
   display: flex;
   flex-direction: column;
   width: 100vw;
-  overflow-x: auto;
+  justify-content: space-between;
+  height:100vh;
+  max-width:1600px;
 }
 </style>
 

--- a/frontend/src/home/Stories.vue
+++ b/frontend/src/home/Stories.vue
@@ -91,7 +91,7 @@ const page = ref(0)
 <style>
 @import '/homepage.css';
 .carousel-container {
-  width: 100vw;
+  max-width:1600px;
   min-width: 90rem;
 }
 .carousel-nav {
@@ -100,7 +100,6 @@ const page = ref(0)
   margin-right: 5em;
   margin-bottom: 4em;
   padding-right: 4rem;
-  width: 100%;
 }
 .carousel-all {
   display: flex;
@@ -113,7 +112,6 @@ const page = ref(0)
   margin-left: 2em;
 }
 .carousel-parent {
-  width: 100vw;
   min-width: 90rem;
 }
 

--- a/frontend/src/views/DataDashboardView.vue
+++ b/frontend/src/views/DataDashboardView.vue
@@ -29,7 +29,7 @@ const changeView = (v) => {
 </script>
 
 <template>
-  <div class="view">
+  <div class="view dashboard-view">
     <div class="dd-header">
       <PresetExploreSelector
         :dataset="route.params.dataset"
@@ -50,6 +50,10 @@ const changeView = (v) => {
 </template>
 
 <style>
+.dashboard-view{
+  position:absolute;
+  top:4rem;
+}
 .dashboard-parent-container {
   padding: 2rem 3rem;
 }

--- a/frontend/src/views/Footer.vue
+++ b/frontend/src/views/Footer.vue
@@ -47,7 +47,16 @@ function goToFAQ() {
   font-family: 'Noto Sans', sans-serif;
   margin-top: 4rem;
 }
-
+#footer::before{
+  content: "";
+   position: absolute;
+   margin-top: -2rem;
+   left: 0;
+   width: 100%;
+   background-color: #000000;
+   height: 10rem;
+   z-index:-1;
+}
 #logo {
   margin: 0 2rem 0 0;
 }

--- a/frontend/src/views/Header.vue
+++ b/frontend/src/views/Header.vue
@@ -61,7 +61,17 @@ function showDataDashboardAsButton(): boolean {
   justify-content: space-between;
   align-items: center;
 }
-
+#header::before{
+  content: "";
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background-color: #181818;
+    height: 4.5rem;
+    z-index:-1;
+}
 .header-links {
   margin: 0 2rem;
   font-family: 'Noto Sans Mono';


### PR DESCRIPTION
DONE in this PR:

- updated formatting to center content on extra-large screens
- fixes #215 

Before: Dashboard at 2200px
<img width="1132" alt="Screen Shot 2023-09-19 at 2 42 50 PM" src="https://github.com/Spelman-College/spelman-dashboard/assets/92114989/56bbef97-3bfe-4559-ac22-492c65de37d9">

After: Dashboard at 2200px
<img width="1132" alt="Screen Shot 2023-09-19 at 2 43 03 PM" src="https://github.com/Spelman-College/spelman-dashboard/assets/92114989/1235c0ff-74aa-4f64-8e4c-ca6e22096275">

Before: Homepage at 2200px
<img width="1132" alt="Screen Shot 2023-09-19 at 2 47 09 PM" src="https://github.com/Spelman-College/spelman-dashboard/assets/92114989/2a610d1e-eb99-47d5-88b8-d50685657b73">


After: Homepage at 2200px
<img width="1132" alt="Screen Shot 2023-09-19 at 2 47 04 PM" src="https://github.com/Spelman-College/spelman-dashboard/assets/92114989/fb54f618-64a0-4786-9aa4-f2b0016e48cd">
