### PR TITLE
fix footer position in dashboard view

### DIFF
--- a/frontend/src/views/DataDashboardView.vue
+++ b/frontend/src/views/DataDashboardView.vue
@@ -50,7 +50,6 @@ const changeView = (v) => {
 </template>
 
 <style>
-
 .dashboard-parent-container {
   padding: 2rem 3rem;
 }

--- a/frontend/src/views/DataDashboardView.vue
+++ b/frontend/src/views/DataDashboardView.vue
@@ -50,10 +50,7 @@ const changeView = (v) => {
 </template>
 
 <style>
-.dashboard-view {
-  position: absolute;
-  top: 4rem;
-}
+
 .dashboard-parent-container {
   padding: 2rem 3rem;
 }


### PR DESCRIPTION
DONE in this PR:
Fix footer position in data dashboard view.

Before: 
<img width="1392" alt="Screen Shot 2023-09-22 at 4 12 25 PM" src="https://github.com/Spelman-College/spelman-dashboard/assets/92114989/71850e9d-4011-48f3-a933-5cc6f0041738">



After: footer is underneath page content
<img width="1392" alt="Screen Shot 2023-09-22 at 4 13 50 PM" src="https://github.com/Spelman-College/spelman-dashboard/assets/92114989/6553cded-29bf-4033-ab51-126690ed31a0">

